### PR TITLE
MAINT: Experiment.timestamp --> Experiment.date

### DIFF
--- a/orsopy/fileio/data_source.py
+++ b/orsopy/fileio/data_source.py
@@ -15,7 +15,7 @@ class Experiment(Header):
     """A definition of the experiment performed."""
     title: str
     instrument: str
-    timestamp: datetime.datetime
+    date: datetime.datetime
     probe: str
     facility: Optional[str] = field(default=None)
     proposalID: Optional[str] = field(default=None)

--- a/tests/test_fileio/test_data_source.py
+++ b/tests/test_fileio/test_data_source.py
@@ -23,7 +23,7 @@ class TestExperiment(unittest.TestCase):
                                                 10), 'X-ray')
         assert value.title == "My First Experiment"
         assert value.instrument == 'A Lab Instrument'
-        assert value.timestamp == datetime(1992, 7, 14, 10, 10, 10)
+        assert value.date == datetime(1992, 7, 14, 10, 10, 10)
         assert value.probe == 'X-ray'
         assert value.facility is None
         assert value.proposalID is None
@@ -38,7 +38,7 @@ class TestExperiment(unittest.TestCase):
                                        datetime(1992, 7, 14, 10, 10,
                                                 10), 'X-ray')
         assert value.to_yaml() == 'title: My First Experiment\n'\
-            + 'instrument: A Lab Instrument\ntimestamp: 1992-07-14T'\
+            + 'instrument: A Lab Instrument\ndate: 1992-07-14T'\
             + '10:10:10\nprobe: X-ray\n'
 
     def test_creation_optionals(self):
@@ -54,7 +54,7 @@ class TestExperiment(unittest.TestCase):
                                        doi='10.0000/abc1234')
         assert value.title == "My First Neutron Experiment"
         assert value.instrument == 'TAS8'
-        assert value.timestamp == datetime(1992, 7, 14, 10, 10, 10)
+        assert value.date == datetime(1992, 7, 14, 10, 10, 10)
         assert value.probe == 'neutron'
         assert value.facility == 'Risoe'
         assert value.proposalID == 'abc123'
@@ -72,7 +72,7 @@ class TestExperiment(unittest.TestCase):
                                        proposalID='abc123',
                                        doi='10.0000/abc1234')
         assert value.to_yaml() == 'title: My First Neutron Experiment\n'\
-            + 'instrument: TAS8\ntimestamp: 1992-07-14T'\
+            + 'instrument: TAS8\ndate: 1992-07-14T'\
             + '10:10:10\nprobe: neutron\nfacility: Risoe\nproposalID: '\
             + 'abc123\ndoi: 10.0000/abc1234\n'
 
@@ -149,6 +149,6 @@ class TestDataSource(unittest.TestCase):
         assert value.owner.affiliation == 'Some Uni'
         assert value.experiment.title == 'My First Experiment'
         assert value.experiment.instrument == 'A Lab Instrument'
-        assert value.experiment.timestamp == datetime(1992, 7, 14, 10, 10, 10)
+        assert value.experiment.date == datetime(1992, 7, 14, 10, 10, 10)
         assert value.experiment.probe == 'X-ray'
         assert value.sample.identifier == 'A Perfect Sample'

--- a/tests/test_fileio/test_orso.py
+++ b/tests/test_fileio/test_orso.py
@@ -66,7 +66,7 @@ class TestOrso(unittest.TestCase):
         fna = pathlib.Path('README.rst')
         assert value.to_yaml() == 'data_source:\n  owner:\n    name: '\
             + 'A Person\n    affiliation: Some Uni\n  experiment:\n    '\
-            + 'title: Experiment 1\n    instrument: ESTIA\n    timestamp: '\
+            + 'title: Experiment 1\n    instrument: ESTIA\n    date: '\
             + '2021-07-07T16:31:10\n    probe: neutron\n  sample:\n    '\
             + 'identifier: The sample\nmeasurement:\n  '\
             + 'instrument_settings:\n    incident_angle:\n      '\
@@ -130,7 +130,7 @@ class TestOrso(unittest.TestCase):
         fna = pathlib.Path('README.rst')
         assert value.to_yaml() == 'data_source:\n  owner:\n    name: '\
             + 'A Person\n    affiliation: Some Uni\n  experiment:\n    '\
-            + 'title: Experiment 1\n    instrument: ESTIA\n    timestamp: '\
+            + 'title: Experiment 1\n    instrument: ESTIA\n    date: '\
             + '2021-07-07T16:31:10\n    probe: neutron\n  sample:\n    '\
             + 'identifier: The sample\nmeasurement:\n  '\
             + 'instrument_settings:\n    incident_angle:\n      '\
@@ -160,7 +160,7 @@ class TestFunctions(unittest.TestCase):
         assert empty.data_source.owner is None
         assert empty.data_source.experiment.title is None
         assert empty.data_source.experiment.instrument is None
-        assert empty.data_source.experiment.timestamp is None
+        assert empty.data_source.experiment.date is None
         assert empty.data_source.experiment.probe is None
         assert empty.data_source.sample.identifier is None
         assert empty.measurement.instrument_settings.incident_angle is None
@@ -182,7 +182,7 @@ class TestFunctions(unittest.TestCase):
         empty = make_empty()
         assert empty.to_yaml() == 'data_source:\n  owner: null\n  '\
             + 'experiment:\n    title: null\n    instrument: null\n    '\
-            + 'timestamp: null\n    probe: null\n  sample:\n    '\
+            + 'date: null\n    probe: null\n  sample:\n    '\
             + 'identifier: null\nmeasurement:\n  '\
             + 'instrument_settings:\n    incident_angle: null\n    '\
             + 'wavelength: null\n    polarization: null\n  '\


### PR DESCRIPTION
According to https://www.reflectometry.org/projects/file_formats/tasks/ws_2021-06_text/, `Experiment` should have a `date` key. This PR renames `Experiment.timestamp` to `Experiment.date`.