### PR TITLE
ENH: file writer for an ORSO object

### DIFF
--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -220,7 +220,7 @@ def _read_header(file):
         header = []
         for line in fi.readlines():
             if not line.startswith("#"):
-                break
+                continue
             header.append(line[1:])
         return "".join(header)
 

--- a/orsopy/fileio/data_source.py
+++ b/orsopy/fileio/data_source.py
@@ -109,10 +109,10 @@ class DataSource(Header):
     experiment: Experiment
     sample: Sample
     measurement: Measurement
-    x: np.ndarray
+    data: np.ndarray
     _orso_optionals = []
 
     def to_dict(self):
         dct = super(DataSource, self).to_dict()
-        dct.pop("x")
+        dct.pop("data")
         return dct

--- a/orsopy/fileio/data_source.py
+++ b/orsopy/fileio/data_source.py
@@ -14,6 +14,7 @@ except ImportError:
     # not available until 3.8
     from typing_extensions import Literal
 
+import numpy as np
 from .base import File, Header, ValueRange, Value, ValueVector, Person
 
 
@@ -108,4 +109,10 @@ class DataSource(Header):
     experiment: Experiment
     sample: Sample
     measurement: Measurement
+    x: np.ndarray
     _orso_optionals = []
+
+    def to_dict(self):
+        dct = super(DataSource, self).to_dict()
+        dct.pop("x")
+        return dct

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -11,6 +11,7 @@ from .data_source import (DataSource, Experiment, Sample, InstrumentSettings,
                           Measurement)
 from .reduction import Reduction, Software
 import datetime
+import numpy as np
 
 
 @dataclass
@@ -41,7 +42,7 @@ def make_empty():
     _instrument_settings = InstrumentSettings(None, None)
     _measurement = Measurement(_instrument_settings, None)
     _data_source = DataSource(
-        _person, _experiment, Sample(None), _measurement
+        _person, _experiment, Sample(None), _measurement, np.array([])
     )
 
     _reduction = Reduction(Software(None, None, None), None, None, None)

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -6,12 +6,18 @@ Implementation of the top level class for the ORSO header.
 
 from typing import List, Union
 from dataclasses import dataclass
-from .base import Header, Column, Person, Creator
+import datetime
+import yaml
+import numpy as np
+
+from .base import Header, Column, Person, Creator, _possibly_open_file
 from .data_source import (DataSource, Experiment, Sample, InstrumentSettings,
                           Measurement)
 from .reduction import Reduction, Software
-import datetime
-import numpy as np
+
+
+ORSO_designate = ("# ORSO reflectivity data file | 0.1 standard | "
+                  "YAML encoding | https://www.reflectometry.org/")
 
 
 @dataclass
@@ -25,6 +31,105 @@ class Orso(Header):
     columns: List[Column]
     data_set: Union[str, List[str]]
     _orso_optionals = []
+
+    def __post_init__(self):
+        if self.columns is None or self.data_source is None:
+            return None
+
+        ncols = len(self.columns)
+        if self.data_source.data.shape[1] < ncols:
+            raise ValueError(
+                "The data must have at least as many columns as those defined"
+                " in ORSO.columns."
+            )
+
+    def add_data_source(self, data_source, data_set):
+        """
+        Adding datasets to an ORSO file.
+        """
+        ncols = len(self.columns)
+        if data_source.data.shape[1] < ncols:
+            raise ValueError(
+                "The data must have at least as many columns as those defined"
+                " in ORSO.columns."
+            )
+
+        if self.n_datasets() > 1:
+            self.data_source.append(data_source)
+            self.data_set.append(data_set)
+        elif self.n_datasets() == 1:
+            ds = self.data_source
+            self.data_source = [ds, data_source]
+            ds = self.data_set
+            self.data_set = [ds, data_set]
+        else:
+            raise RuntimeError(
+                "Problem adding a data_source to the ORSO object")
+
+    def n_datasets(self):
+        if isinstance(self.data_source, list):
+            return len(self.data_source)
+        elif isinstance(self.data_source, DataSource):
+            return 1
+
+    def save(self, fname):
+        """
+        Save an ORSO file
+
+        Parameters
+        ----------
+        fname: str
+        """
+        def to_yaml(entry, attr):
+            return yaml.dump(
+                {entry: attr.to_dict()}, sort_keys=False
+            )
+
+        # Here we assemble the file by converting individual parts to yaml
+        # strings, rather than just calling self.to_yaml().
+        # This is because the specification says that successive datasets are
+        # separated by data_source yaml sections. Unfortunately self.to_yaml()
+        # would place all the data_source attributes in a single list at the
+        # top of the file.
+        with open(fname, "wt+") as f:
+            header = [f"{ORSO_designate}\n"]
+            # write out the first dataset
+            header.append(to_yaml("creator", self.creator))
+
+            if self.n_datasets() > 1:
+                dsource = self.data_source[0]
+                dset = self.data_set[0]
+            else:
+                dsource = self.data_source
+                dset = self.data_set
+
+            header.append(to_yaml("data_source", dsource))
+            header.append(to_yaml("reduction", self.reduction))
+
+            cols = [col.to_dict() for col in self.columns]
+            header.append(yaml.dump({"columns": cols}, sort_keys=False))
+
+            header.append(f"data_set: {dset}")
+
+            data = dsource.data
+            np.savetxt(f, data, header="".join(header))
+
+            # write out subsequent datasets
+            for i in range(1, self.n_datasets()):
+                dsource = self.data_source[i]
+                dset = self.data_set[i]
+
+                h = [to_yaml("data_source", dsource), f"data_set: {dset}"]
+                np.savetxt(f, dsource.data, header="".join(h))
+
+    @classmethod
+    def from_file(cls, f):
+        """
+        Read an ORSO file
+        """
+        with _possibly_open_file(f, 'r'):
+            # TODO IMPLEMENT
+            pass
 
 
 def make_empty():

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -158,9 +158,7 @@ class Orso(Header):
         # data_source
         # if the number of data_source is 1, then data_source will be a dict
         # otherwise it'll be a list
-        num_datasets = len(data)
-        _ds_dct= dct['data_source'].copy()
-        print(h)
+        _ds_dct = dct['data_source'].copy()
 
         if hasattr(_ds_dct, "len"):
             ds = []
@@ -214,14 +212,15 @@ def _make_data_source(ds_dct, data):
         return df
 
     if isinstance(meas['data_files'], list):
-        meas['data_files'] = [dfs_converter(df) for df in  meas['data_files']]
+        meas['data_files'] = [dfs_converter(df) for df in meas['data_files']]
     else:
         meas['data_files'] = dfs_converter(meas['data_files'])
 
     dfr = meas.get("references", None)
     if dfr is not None:
         if isinstance(meas['references'], list):
-            meas['references'] = [dfs_converter(df) for df in  meas['references']]
+            meas['references'] = [dfs_converter(df)
+                                  for df in meas['references']]
         else:
             meas['references'] = dfs_converter(meas['references'])
 

--- a/orsopy/fileio/reduction.py
+++ b/orsopy/fileio/reduction.py
@@ -24,11 +24,12 @@ class Reduction(Header):
     """A description of the reduction that has been performed."""
     software: Union[Software, str]
     time: Optional[datetime.datetime] = field(
+        default=None,
         metadata={
             "description": "Timestamp string, formatted as ISO 8601 datetime"
         })
-    creator: Optional[Person]
-    corrections: Optional[List[str]]
+    creator: Optional[Person] = None
+    corrections: Optional[List[str]] = None
     computer: Optional[str] = field(
         default=None, metadata={'description': 'Computer used for reduction'})
     call: Optional[str] = field(

--- a/tests/test_fileio/test_data_source.py
+++ b/tests/test_fileio/test_data_source.py
@@ -7,6 +7,7 @@ Tests for fileio.data_source module
 import unittest
 import pathlib
 from datetime import datetime
+import numpy as np
 from orsopy.fileio import data_source, base
 
 
@@ -150,13 +151,15 @@ class TestDataSource(unittest.TestCase):
             base.File("2.nx.hdf", datetime.now())
         ]
         m = data_source.Measurement(inst, df, scheme="angle-dispersive")
-
+        x = np.zeros((100, 4))
         value = data_source.DataSource(
             base.Person('A Person', 'Some Uni'),
             data_source.Experiment('My First Experiment', 'A Lab Instrument',
                                    datetime(1992, 7, 14, 10, 10, 10), 'X-ray'),
             data_source.Sample('A Perfect Sample'),
-            m)
+            m,
+            x
+        )
         assert value.owner.name == 'A Person'
         assert value.owner.affiliation == 'Some Uni'
         assert value.experiment.title == 'My First Experiment'
@@ -164,6 +167,7 @@ class TestDataSource(unittest.TestCase):
         assert value.experiment.date == datetime(1992, 7, 14, 10, 10, 10)
         assert value.experiment.probe == 'X-ray'
         assert value.sample.name == 'A Perfect Sample'
+        assert value.x.shape == (100, 4)
 
 
 class TestInstrumentSettings(unittest.TestCase):

--- a/tests/test_fileio/test_data_source.py
+++ b/tests/test_fileio/test_data_source.py
@@ -167,7 +167,7 @@ class TestDataSource(unittest.TestCase):
         assert value.experiment.date == datetime(1992, 7, 14, 10, 10, 10)
         assert value.experiment.probe == 'X-ray'
         assert value.sample.name == 'A Perfect Sample'
-        assert value.x.shape == (100, 4)
+        assert value.data.shape == (100, 4)
 
 
 class TestInstrumentSettings(unittest.TestCase):

--- a/tests/test_fileio/test_orso.py
+++ b/tests/test_fileio/test_orso.py
@@ -7,6 +7,7 @@ Tests for fileio module
 import unittest
 import pathlib
 from datetime import datetime
+import numpy as np
 from orsopy.fileio.orso import Orso, make_empty
 from orsopy.fileio.data_source import (DataSource, Experiment, Sample,
                                        Measurement, InstrumentSettings)
@@ -37,7 +38,8 @@ class TestOrso(unittest.TestCase):
         df = [File('README.rst', None)]
         m = Measurement(inst, df, scheme="angle-dispersive")
         p = Person('A Person', 'Some Uni')
-        ds = DataSource(p, e, s, m)
+        x = np.zeros((100, 4))
+        ds = DataSource(p, e, s, m, x)
 
         soft = Software('orsopy', '0.0.1', 'macOS-10.15')
         p2 = Person('Andrew McCluskey', 'European Spallation Source')
@@ -54,6 +56,7 @@ class TestOrso(unittest.TestCase):
         ds = value.data_source
         dsm = ds.measurement
         assert ds.owner.name == 'A Person'
+        assert ds.x.shape == (100, 4)
         assert dsm.data_files[0].file == 'README.rst'
         assert dsm.instrument_settings.incident_angle.magnitude == 4.0
         assert dsm.instrument_settings.wavelength.min == 2.0
@@ -91,7 +94,8 @@ class TestOrso(unittest.TestCase):
         df = [File('README.rst', None)]
         m = Measurement(inst, df, scheme="angle-dispersive")
         p = Person('A Person', 'Some Uni')
-        ds = DataSource(p, e, s, m)
+        x = np.zeros((100, 4))
+        ds = DataSource(p, e, s, m, x)
 
         soft = Software('orsopy', '0.0.1', 'macOS-10.15')
         p2 = Person('Andrew McCluskey', 'European Spallation Source')
@@ -105,6 +109,7 @@ class TestOrso(unittest.TestCase):
 
         dsm = value.data_source.measurement
         assert value.data_source.owner.name == 'A Person'
+        assert value.data_source.x.shape == (100, 4)
         assert dsm.data_files[0].file == 'README.rst'
         assert value.reduction.software.name == 'orsopy'
         assert value.columns[0].name == 'Qz'

--- a/tests/test_fileio/test_orso.py
+++ b/tests/test_fileio/test_orso.py
@@ -8,12 +8,12 @@ import unittest
 import pathlib
 from datetime import datetime
 import numpy as np
-from orsopy.fileio.orso import Orso, make_empty
+from orsopy.fileio.orso import Orso, make_empty, ORSO_designate
 from orsopy.fileio.data_source import (DataSource, Experiment, Sample,
                                        Measurement, InstrumentSettings)
 from orsopy.fileio.reduction import Reduction, Software
 from orsopy.fileio.base import Person, ValueRange, Value, File, Column, Creator
-from orsopy.fileio.base import _validate_header
+from orsopy.fileio.base import _validate_header, _read_header
 
 
 class TestOrso(unittest.TestCase):
@@ -56,7 +56,7 @@ class TestOrso(unittest.TestCase):
         ds = value.data_source
         dsm = ds.measurement
         assert ds.owner.name == 'A Person'
-        assert ds.x.shape == (100, 4)
+        assert ds.data.shape == (100, 4)
         assert dsm.data_files[0].file == 'README.rst'
         assert dsm.instrument_settings.incident_angle.magnitude == 4.0
         assert dsm.instrument_settings.wavelength.min == 2.0
@@ -69,11 +69,7 @@ class TestOrso(unittest.TestCase):
         assert value.data_set == 0
 
         h = value.to_yaml()
-        h = "\n".join(
-            ["# ORSO reflectivity data file | 0.1 standard | YAML encoding"
-             " | https://www.reflectometry.org/",
-             h]
-        )
+        h = "\n".join([ORSO_designate, h])
         _validate_header(h)
 
     def test_creation_data_set1(self):
@@ -109,11 +105,48 @@ class TestOrso(unittest.TestCase):
 
         dsm = value.data_source.measurement
         assert value.data_source.owner.name == 'A Person'
-        assert value.data_source.x.shape == (100, 4)
+        assert value.data_source.data.shape == (100, 4)
         assert dsm.data_files[0].file == 'README.rst'
         assert value.reduction.software.name == 'orsopy'
         assert value.columns[0].name == 'Qz'
         assert value.data_set == 1
+
+    def test_write(self):
+        c = Creator(
+            'A Person', 'Some Uni', "wally@wallyland.com", datetime.now(), ""
+        )
+        e = Experiment(
+            'Experiment 1', 'ESTIA', datetime(2021, 7, 7, 16, 31, 10),
+            'neutrons'
+        )
+        s = Sample('The sample')
+        inst = InstrumentSettings(
+            Value(4.0, 'deg'), ValueRange(2., 12., 'angstrom')
+        )
+        df = [File('README.rst', None)]
+        m = Measurement(inst, df, scheme="angle-dispersive")
+        p = Person('A Person', 'Some Uni')
+        x = np.zeros((100, 4))
+        ds = DataSource(p, e, s, m, x)
+
+        soft = Software('orsopy', '0.0.1', 'macOS-10.15')
+        p2 = Person('Andrew McCluskey', 'European Spallation Source')
+        redn = Reduction(
+            soft, datetime(2021, 7, 14, 10, 10, 10),
+            p2, ['footprint', 'background']
+        )
+
+        cols = [Column("Qz"), Column("R")]
+        value = Orso(c, ds, redn, cols, 0)
+        value.save("test.ort")
+        h = _read_header("test.ort")
+        _validate_header(h)
+
+        # now make a file with two datasets in it.
+        value.add_data_source(ds, 1)
+        value.save("test1.ort")
+        h = _read_header("test1.ort")
+        _validate_header(h)
 
 
 class TestFunctions(unittest.TestCase):

--- a/tests/test_fileio/test_orso.py
+++ b/tests/test_fileio/test_orso.py
@@ -160,7 +160,6 @@ class TestOrso(unittest.TestCase):
         # assert len(o.data_source) == 2
 
     def test_load(self):
-        pth = os.path.dirname(orsopy.__file__)
         o = Orso.from_file(os.path.join("tests", "test_example.ort"))
         assert isinstance(o, Orso)
         assert o.creator.name == "G. User"

--- a/tests/test_fileio/test_orso.py
+++ b/tests/test_fileio/test_orso.py
@@ -13,7 +13,7 @@ from orsopy.fileio.data_source import (DataSource, Experiment, Sample,
                                        Measurement, InstrumentSettings)
 from orsopy.fileio.reduction import Reduction, Software
 from orsopy.fileio.base import Person, ValueRange, Value, File, Column, Creator
-from orsopy.fileio.base import _validate_header, _read_header
+from orsopy.fileio.base import _validate_header, _read_header_data
 
 
 class TestOrso(unittest.TestCase):
@@ -139,14 +139,18 @@ class TestOrso(unittest.TestCase):
         cols = [Column("Qz"), Column("R")]
         value = Orso(c, ds, redn, cols, 0)
         value.save("test.ort")
-        h = _read_header("test.ort")
+        h, datasets = _read_header_data("test.ort")
         _validate_header(h)
+        assert len(datasets) == 1
+        assert datasets[0].shape == (100, 4)
 
         # now make a file with two datasets in it.
         value.add_data_source(ds, 1)
         value.save("test1.ort")
-        h = _read_header("test1.ort")
+        h, datasets = _read_header_data("test1.ort")
         _validate_header(h)
+        assert len(datasets) == 2
+        assert datasets[0].shape == datasets[1].shape == (100, 4)
 
 
 class TestFunctions(unittest.TestCase):

--- a/tests/test_fileio/test_orso.py
+++ b/tests/test_fileio/test_orso.py
@@ -6,8 +6,10 @@ Tests for fileio module
 
 import unittest
 import pathlib
+import os.path
 from datetime import datetime
 import numpy as np
+import orsopy
 from orsopy.fileio.orso import Orso, make_empty, ORSO_designate
 from orsopy.fileio.data_source import (DataSource, Experiment, Sample,
                                        Measurement, InstrumentSettings)
@@ -151,6 +153,32 @@ class TestOrso(unittest.TestCase):
         _validate_header(h)
         assert len(datasets) == 2
         assert datasets[0].shape == datasets[1].shape == (100, 4)
+
+        # read that multi-dataset file back in.
+        # o = Orso.from_file("test1.ort")
+        # print(o.data_source)
+        # assert len(o.data_source) == 2
+
+    def test_load(self):
+        pth = os.path.dirname(orsopy.__file__)
+        o = Orso.from_file(os.path.join("tests", "test_example.ort"))
+        assert isinstance(o, Orso)
+        assert o.creator.name == "G. User"
+        assert len(o.columns) == 4
+        cnames = [c.name for c in o.columns]
+        assert cnames == ["Qz", "R", "sR", "sQz"]
+        assert o.reduction.software == 'eos.py'
+        assert o.reduction.corrections == [
+            "footprint", "incident intensity", "detector efficiency"
+        ]
+        assert o.data_set == "spin_up"
+        ds = o.data_source
+        assert isinstance(ds, DataSource)
+        assert ds.measurement.scheme == "angle- and energy-dispersive"
+        assert ds.measurement.instrument_settings.wavelength.min == 3.0
+        assert ds.measurement.data_files[1].file == "amor2020n001926.hdf"
+        assert ds.measurement.references[0].file == "amor2020n001064.hdf"
+        assert ds.data.shape == (2, 4)
 
 
 class TestFunctions(unittest.TestCase):

--- a/tests/test_fileio/test_schema.py
+++ b/tests/test_fileio/test_schema.py
@@ -3,7 +3,7 @@ import os.path
 import jsonschema
 import yaml
 import orsopy
-from orsopy.fileio.base import _read_header, _validate_header
+from orsopy.fileio.base import _read_header_data, _validate_header
 
 
 class TestSchema:
@@ -13,7 +13,7 @@ class TestSchema:
         with open(schema_pth, "r") as f:
             schema = json.load(f)
 
-        header = _read_header(os.path.join("tests", "test_example.ort"))
+        header, datasets = _read_header_data(os.path.join("tests", "test_example.ort"))
         d = yaml.safe_load(header)
         # d contains datetime.datetime objects, which would fail the
         # jsonschema validation, so force those to be strings.

--- a/tests/test_fileio/test_schema.py
+++ b/tests/test_fileio/test_schema.py
@@ -13,7 +13,9 @@ class TestSchema:
         with open(schema_pth, "r") as f:
             schema = json.load(f)
 
-        header, datasets = _read_header_data(os.path.join("tests", "test_example.ort"))
+        header, datasets = _read_header_data(
+            os.path.join("tests", "test_example.ort")
+        )
         d = yaml.safe_load(header)
         # d contains datetime.datetime objects, which would fail the
         # jsonschema validation, so force those to be strings.


### PR DESCRIPTION
This PR:

1. adds the `ORSO.save` method to write the object to file.
2. adds a data attribute to `DataSource`.
3. adds the `ORSO.add_data_source` method
4. tests that the ORSO header from the saved file is valid.
5. adds functionality to load the data-arrays from an ORSO file.
6. re-reads the ORSO file