### PR TITLE
ENH: user_data

### DIFF
--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -82,7 +82,14 @@ class Header(metaclass=HeaderMeta):
                     # convert to dataclass instance
                     setattr(self, fld.name, updt)
                 else:
-                    raise ValueError(f"No suitable conversion found for {fld.type} with value {attr}")
+                    warnings.warn(
+                        f"No suitable conversion found for {fld.name}, "
+                        f"{fld.type} with value {attr}, "
+                        "setting attribute with raw value from ORSO file",
+                        RuntimeWarning
+                    )
+                    setattr(self, fld.name, attr)
+                    # raise ValueError(f"No suitable conversion found for {fld.type} with value {attr}")
         if hasattr(self, 'unit'):
             self._check_unit(self.unit)
 
@@ -110,7 +117,9 @@ class Header(metaclass=HeaderMeta):
             if hbase in (list, tuple):
                 t0 = get_args(hint)[0]
                 if isinstance(item, (list, tuple)):
-                    return [Header._resolve_type(t0, i) for i in item]
+                    return type(item)(
+                        [Header._resolve_type(t0, i) for i in item]
+                    )
                 else:
                     return [Header._resolve_type(t0, item)]
             elif hbase in [Union, Optional]:

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -6,8 +6,8 @@ Implementation of the top level class for the ORSO header.
 
 import re
 import yaml
-from typing import List, Union, TextIO, Optional
-from dataclasses import dataclass
+from typing import List, Union, TextIO, Optional, Any
+from dataclasses import dataclass, field
 from .base import (Header, Column, Creator, _possibly_open_file,
                    _read_header_data, _nested_update, _dict_diff)
 from .data_source import DataSource
@@ -24,12 +24,18 @@ ORSO_DESIGNATE = (f"# ORSO reflectivity data file | {ORSO_VERSION} standard "
 class Orso(Header):
     """
     The Orso object collects the necessary metadata.
+    Extra information not part of the official Orso specification may be
+    stored in `user_data`.
     """
     creator: Creator
     data_source: DataSource
     reduction: Reduction
-    data_set: Union[str, int]
     columns: List[Column]
+    data_set: Union[str, int] = None
+    user_data: Optional[Any] = field(
+        default=None,
+        metadata={"description": "Extra information not part of the official Orso specification"}
+    )
 
     __repr__ = Header._staggered_repr
 
@@ -195,6 +201,7 @@ def load_orso(fname: Union[TextIO, str]) -> List[OrsoDataset]:
     """
     dct_list, datas, version = _read_header_data(fname)
     ods = []
+
     for dct, data in zip(dct_list, datas):
         o = Orso(**dct)
         od = OrsoDataset(o, data)

--- a/tests/test_fileio/test_orso.py
+++ b/tests/test_fileio/test_orso.py
@@ -53,7 +53,7 @@ class TestOrso(unittest.TestCase):
         )
 
         cols = [Column("Qz"), Column("R")]
-        value = Orso(c, ds, redn, 0, cols)
+        value = Orso(c, ds, redn, cols, 0)
 
         assert value.creator.name == "A Person"
         assert value.creator.contact == "wally@wallyland.com"
@@ -109,7 +109,7 @@ class TestOrso(unittest.TestCase):
         )
 
         cols = [Column("Qz"), Column("R")]
-        value = Orso(c, ds, redn, 1, cols)
+        value = Orso(c, ds, redn, cols, 1)
 
         dsm = value.data_source.measurement
         assert value.data_source.owner.name == 'A Person'
@@ -202,6 +202,33 @@ class TestOrso(unittest.TestCase):
             fileio.save_orso([ds, ds2], 'test_data_set.ort')
 
 
+    def test_user_data(self):
+        # test write and read of userdata
+        info = fileio.Orso.empty()
+        info.columns = [
+            fileio.Column("Qz", "1/angstrom"),
+            fileio.Column("R"),
+            fileio.Column("sR"),
+        ]
+
+        data = np.zeros((100, 3))
+        data[:] = np.arange(100.0)[:, None]
+        dct = {"ci": "1", "foo": ["bar", 1, 2, 3]}
+        info.user_data = dct
+        ds = fileio.OrsoDataset(info, data)
+
+        fileio.save_orso([ds], "test2.ort")
+        with pytest.warns(RuntimeWarning):
+            ls = fileio.load_orso("test2.ort")
+        assert ls[0].info.user_data == info.user_data
+
+        info.user_data = 12398098
+        fileio.save_orso([ds], "test2.ort")
+        with pytest.warns(RuntimeWarning):
+            ls = fileio.load_orso("test2.ort")
+        assert ls[0].info.user_data == info.user_data
+
+
 class TestFunctions(unittest.TestCase):
     """
     Tests for functionality in the Orso module.
@@ -250,6 +277,5 @@ class TestFunctions(unittest.TestCase):
             '    instrument_settings:\n      incident_angle:\n        magnitude: null\n'
             '      wavelength:\n        magnitude: null\n      polarization: unpolarized\n'
             '    data_files: null\nreduction:\n  software:\n    name: null\n'
-            'data_set: null\ncolumns:\n- name: null\n'
-
+            'columns:\n- name: null\ndata_set: null\n'
         )

--- a/tests/test_fileio/test_orso.py
+++ b/tests/test_fileio/test_orso.py
@@ -201,7 +201,6 @@ class TestOrso(unittest.TestCase):
         with pytest.raises(ValueError):
             fileio.save_orso([ds, ds2], 'test_data_set.ort')
 
-
     def test_user_data(self):
         # test write and read of userdata
         info = fileio.Orso.empty()


### PR DESCRIPTION
@aglavic, did you have something like this in mind for `user_data`? Note that you can't have a `**kwds` parameter for a dataclass.

Also, when I was writing a test I found that there was a problem with saving/reloading an ORT file with a single dataset. Currently the specification doesn't mandate that `data_set` be present in a file when there is only a single dataset:

> If there are multiple data sets in one file, the first one can be given an identifier with the optional line:

The existing code doesn't save the `data_set` attribute when [`data_set == 0`](https://github.com/reflectivity/orsopy/blob/c5c7cdc68660ff927ce1b95b490af5625e5d4145/orsopy/fileio/base.py#L173)
This is a problem when reconstructing the `Orso` object because the constructor requires `data_set` as a positional parameter, but it's not present in the loaded dict (`Orso(**dct)`). To get around this I made `data_set` a keyword argument with a default of None, moving it after the positional args. I also typed it as `Optional` because it's not needed when working with a single dataset.

Alternatively we can make it mandatory in the specification that `data_set` is provided for each dataset, and make sure it's written in a file. In which case we can revert the changes in this PR, removing the  [`data_set == 0` check](https://github.com/reflectivity/orsopy/blob/c5c7cdc68660ff927ce1b95b490af5625e5d4145/orsopy/fileio/base.py#L173).