### PR TITLE
MAINT: don't remove data_set from to_dict.

### DIFF
--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -170,8 +170,6 @@ class Header(metaclass=HeaderMeta):
                     else:
                         cleaned_list.append(j)
                 out_dict[i] = type(value)(cleaned_list)
-            elif i == "data_set" and value == 0:
-                continue
             else:
                 # here _todict converts objects that aren't derived from Header
                 # and therefore don't have to_dict methods.


### PR DESCRIPTION
The presence of `data_set` in the yaml header is optional if there is only one dataset. However, the specification doesn't say it *has* to be be removed.