### PR TITLE
MAINT: optional Orso.data_set

### DIFF
--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -28,8 +28,8 @@ class Orso(Header):
     creator: Creator
     data_source: DataSource
     reduction: Reduction
-    data_set: Union[str, int]
     columns: List[Column]
+    data_set: Optional[Union[int, str]] = None
 
     __repr__ = Header._staggered_repr
 
@@ -195,6 +195,7 @@ def load_orso(fname: Union[TextIO, str]) -> List[OrsoDataset]:
     """
     dct_list, datas, version = _read_header_data(fname)
     ods = []
+
     for dct, data in zip(dct_list, datas):
         o = Orso(**dct)
         od = OrsoDataset(o, data)

--- a/tests/test_fileio/test_orso.py
+++ b/tests/test_fileio/test_orso.py
@@ -53,7 +53,7 @@ class TestOrso(unittest.TestCase):
         )
 
         cols = [Column("Qz"), Column("R")]
-        value = Orso(c, ds, redn, 0, cols)
+        value = Orso(c, ds, redn, cols, 0)
 
         assert value.creator.name == "A Person"
         assert value.creator.contact == "wally@wallyland.com"
@@ -69,7 +69,8 @@ class TestOrso(unittest.TestCase):
         assert value.reduction.time == datetime(2021, 7, 14, 10, 10, 10)
         assert value.columns[0].name == 'Qz'
         assert value.columns[1].name == 'R'
-        assert value.data_set == '0'
+        print(value.data_set, type(value.data_set))
+        assert value.data_set == 0
 
         h = value.to_yaml()
         h = "\n".join(
@@ -109,13 +110,20 @@ class TestOrso(unittest.TestCase):
         )
 
         cols = [Column("Qz"), Column("R")]
-        value = Orso(c, ds, redn, 1, cols)
+        value = Orso(c, ds, redn, cols, 1)
 
         dsm = value.data_source.measurement
         assert value.data_source.owner.name == 'A Person'
         assert dsm.data_files[0].file == 'README.rst'
         assert value.reduction.software.name == 'orsopy'
         assert value.columns[0].name == 'Qz'
+        assert value.data_set == 1
+
+        # check that data_set can also be a string.
+        value = Orso(c, ds, redn, cols, 'fokdoks')
+        assert value.data_set == 'fokdoks'
+        # don't want class construction coercing a str to an int
+        value = Orso(c, ds, redn, cols, '1')
         assert value.data_set == '1'
 
     def test_write_read(self):
@@ -241,7 +249,7 @@ class TestFunctions(unittest.TestCase):
         TODO: Fix once correct format is known.
         """
         empty = Orso.empty()
-        assert empty.to_yaml() == (
+        req = (
             'creator:\n  name: null\n  affiliation: null\n  time: null\n'
             '  computer: null\ndata_source:\n  owner:\n    name: null\n'
             '    affiliation: null\n  experiment:\n    title: null\n'
@@ -250,6 +258,6 @@ class TestFunctions(unittest.TestCase):
             '    instrument_settings:\n      incident_angle:\n        magnitude: null\n'
             '      wavelength:\n        magnitude: null\n      polarization: unpolarized\n'
             '    data_files: null\nreduction:\n  software:\n    name: null\n'
-            'data_set: null\ncolumns:\n- name: null\n'
-
+            'columns:\n- name: null\n'
         )
+        assert empty.to_yaml() == req


### PR DESCRIPTION
The specification says that `Orso.data_set` is only mandatory for multiple datasets in a file. This means that it should be marked as `Optional` in the dataclass.

Also, if it's not present in an ORT file (if there's only 1 dataset), then it will need to be a kwd argument when constructing the `Orso` object because it won't be present in the loaded json dict. kwd arguments need to come after positional arguments.