### PR TITLE
ENH: pop unknown args

### DIFF
--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -114,8 +114,19 @@ class Header(metaclass=HeaderMeta):
                     return None
             if issubclass(hint, Header):
                 # convert to dataclass instance
+                attribs = hint.__annotations__.keys()
+                realised_items = {k:item[k] for k in item.keys() if k in attribs}
+                # orphan items are extra dictionary entries that don't correspond to
+                # arguments of a Header instance. They can't be used to construct
+                # a header instance, so remove them from the dict of arguments
+                orphan_items = {k:item[k] for k in item.keys() if k not in attribs}
                 try:
-                    return hint(**item)
+                    value = hint(**realised_items)
+                    # however, keep the orphan items with the newly constructed
+                    # Header item.
+                    for k, it in orphan_items.items():
+                        setattr(value, k, it)
+                    return value
                 except (ValueError, TypeError):
                     return None
             else:

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -115,11 +115,16 @@ class Header(metaclass=HeaderMeta):
             if issubclass(hint, Header):
                 # convert to dataclass instance
                 attribs = hint.__annotations__.keys()
-                realised_items = {k:item[k] for k in item.keys() if k in attribs}
+                realised_items = {
+                    k: item[k] for k in item.keys() if k in attribs
+                }
                 # orphan items are extra dictionary entries that don't correspond to
                 # arguments of a Header instance. They can't be used to construct
                 # a header instance, so remove them from the dict of arguments
-                orphan_items = {k:item[k] for k in item.keys() if k not in attribs}
+                orphan_items = {
+                    k: item[k] for k in item.keys() if k not in attribs
+                }
+
                 try:
                     value = hint(**realised_items)
                     # however, keep the orphan items with the newly constructed

--- a/tests/test_example.ort
+++ b/tests/test_example.ort
@@ -48,7 +48,7 @@
 #                  resolution:
 #                      type: proportional
 #                      value: 0.022 # Delta lambda / lambda
-#             polarisation: p
+#             polarization: p
 #         data_files:
 #             - file      : amor2020n001925.hdf
 #               timestamp : 2020-02-03T14:27:45+01:00

--- a/tests/test_example2.ort
+++ b/tests/test_example2.ort
@@ -45,7 +45,7 @@
 #                  resolution:
 #                      type: proportional
 #                      value: 0.022 # Delta lambda / lambda
-#             polarisation: p
+#             polarization: p
 #         data_files:
 #             - file      : amor2020n001925.hdf
 #               timestamp : 2020-02-03T14:27:45


### PR DESCRIPTION
Problem: a file that is read could contain more entries than can be used to construct a Header instance, e.g.
```
@dataclass
class A:
    a: int
```
cannot be constructed as `A(**{"a":1, "b":2})` because there is an unexpected keyword 'b'.
This PR removes the unknown arguments by examining `A.__annotations__.keys()` and removing the unknown parameters.
It then adds those unknown arguments to `A` once the instance is constructed. These unknown items won't enjoy the full status of a dataclass field, but the way the `Header` class is setup they'll still be output in the yaml representation.