### PR TITLE
pin jsonschema to 3.2.0

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,5 +11,5 @@ numpy>=1.19.0
 
 pytest==6.2.4
 pyyaml>=5.4.1
-jsonschema
+jsonschema==3.2.0
 typing_extensions


### PR DESCRIPTION
jsonschema released a 4.0.1 update that appears to break the schema testing. I have pinned to 3.2.0 (the previous release) until we can investigate further.