### PR TITLE
use draft-7 json-schema metaschema

### DIFF
--- a/orsopy/fileio/schema/refl_header.schema.json
+++ b/orsopy/fileio/schema/refl_header.schema.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ORSOHeader",
   "type": "object",
   "properties": {

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,5 +11,5 @@ numpy>=1.19.0
 
 pytest==6.2.4
 pyyaml>=5.4.1
-jsonschema==3.2.0
+jsonschema>=3.2.0
 typing_extensions

--- a/tools/header_schema.py
+++ b/tools/header_schema.py
@@ -224,7 +224,8 @@ class ORSOHeader:
 
 
 if GENERATE_SCHEMA:
-    schema = ORSOHeader.__pydantic_model__.schema()
+    schema = {"$schema": "http://json-schema.org/draft-07/schema#"}
+    schema.update(ORSOHeader.__pydantic_model__.schema())
     print(schema)
     import json
 


### PR DESCRIPTION
Reverting to python package jsonschema < 4 fixes a validation problem with our schema, but only as an indirect side-effect of using an older validation metaschema.  It is probably better to specify the metaschema that should be used.  Then the version of the python package doesn't matter.