### PR TITLE
Replace Meta Class by decorator of same functionality

### DIFF
--- a/orsopy/fileio/data_source.py
+++ b/orsopy/fileio/data_source.py
@@ -8,7 +8,7 @@ Implementation of the data_source for the ORSO header.
 from typing import Optional, Dict, List, Union
 from dataclasses import field, dataclass
 
-from .base import File, Header, ValueRange, Value, ValueVector, Person
+from .base import orsodataclass, File, Header, ValueRange, Value, ValueVector, Person
 
 # typing stuff introduced in python 3.8
 try:
@@ -17,6 +17,7 @@ except ImportError:
     from .typing_backport import Literal
 
 
+@orsodataclass
 class Experiment(Header):
     """
     A definition of the experiment performed.
@@ -40,6 +41,7 @@ class Experiment(Header):
     doi: Optional[str] = None
 
 
+@orsodataclass
 class Sample(Header):
     """
     A description of the sample measured.
@@ -89,6 +91,7 @@ class Sample(Header):
 #     pp = "++"
 
 
+@orsodataclass
 class InstrumentSettings(Header):
     """
     Settings associated with the instrumentation.
@@ -129,6 +132,7 @@ class InstrumentSettings(Header):
     __repr__ = Header._staggered_repr
 
 
+@orsodataclass
 class Measurement(Header):
     """
     The measurement elements for the header.
@@ -152,6 +156,7 @@ class Measurement(Header):
     __repr__ = Header._staggered_repr
 
 
+@orsodataclass
 class DataSource(Header):
     """
     The data_source object definition.

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -7,7 +7,7 @@ Implementation of the top level class for the ORSO header.
 import yaml
 from typing import List, Union, TextIO, Optional, Any
 from dataclasses import dataclass
-from .base import (Header, Column, _possibly_open_file,
+from .base import (orsodataclass, Header, Column, _possibly_open_file,
                    _read_header_data, _nested_update, _dict_diff)
 from .data_source import DataSource
 from .reduction import Reduction
@@ -20,6 +20,7 @@ ORSO_DESIGNATE = (f"# ORSO reflectivity data file | {ORSO_VERSION} standard "
                   "| YAML encoding | https://www.reflectometry.org/")
 
 
+@orsodataclass
 class Orso(Header):
     """
     The Orso object collects the necessary metadata.

--- a/orsopy/fileio/reduction.py
+++ b/orsopy/fileio/reduction.py
@@ -7,9 +7,10 @@ The reduction elements for the ORSO header
 from typing import Optional, List, Union
 from dataclasses import field
 import datetime
-from .base import Header, Person
+from .base import orsodataclass, Header, Person
 
 
+@orsodataclass
 class Software(Header):
     """
     Software description.
@@ -23,6 +24,7 @@ class Software(Header):
     platform: Optional[str] = None
 
 
+@orsodataclass
 class Reduction(Header):
     """
     A description of the reduction that has been performed.


### PR DESCRIPTION
I think some of you were not so happy with the Meta Class solution for the creation of the dataclasses and it turns out that some static analyzers like the one used by PyCharm can't handle this well and generate false positives for wrong parameters when creating the objects.

This is an alternative that replaces it with a decorator solution of equivalent functionality. This way we also follow the same logic as the build-in dataclass.