### PR TITLE
Include slddb sub-package in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,10 @@ jobs:
         sudo apt update
         sudo apt install python3 python3-setuptools python3-pip python3-yaml
         pip3 install build
+    - name: Add slddb package
+      run: |
+        git clone https://github.com/reflectivity/slddb.git slddb_source
+        mv slddb_source/slddb orsopy/
     - name: Build PyPI package
       run: |
         python3 -m build

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include LICENSE
 include README.rst
 
 recursive-include tests *
+recursive-include orsopy/slddb/element_table/nabs_geant4 *.npz
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,9 +23,10 @@ classifiers =
 
 [options]
 python_requires = >=3.8
-packages =
-    orsopy
-    orsopy.fileio
+packages = find:
 install_requires =
     pyyaml>=5.4.1
 include_package_data = True
+
+[options.package_data]
+orsopy.slddb.element_table = nabs_geant4/*.npz


### PR DESCRIPTION
The slddb website allows access via API requests and includes a python package that implements this access.

This change clones the package during PyPI build into orsopy so it can be distributed together.
Example how to use it:
```python
from orsopy.slddb import api, constants

results=api.search(formula='Co')
m=api.material(results[0]['ID'])
print(f"neutron SLD is {m.rho_n}")
print(f"Cu k-alpha SLD is {m.rho_of_E(constants.Cu_kalpha)}")

p=api.bio_blender('aaba', molecule='protein')
print(f'Protein match point is {100*p.match_exchange(D_fraction=0.0, exchange=0.9):.2f}% for 90% exchange')
```