### PR TITLE
Guidelines how to autoformat the code

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,31 @@
+name: Code Format Check
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+          if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
+
+      - name: Lint
+        run: |
+          flake8 --max-line-length=120 --ignore=F401,W503 --count --show-source --statistics orsopy
+          flake8 --max-line-length=120 --ignore=F401,W503 --count --show-source --statistics tests

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Lint
         run: |
-          flake8 --ignore=F401,E501 --count --show-source --statistics orsopy
-          flake8 --ignore=F401,E501 --count --show-source --statistics tests
+          flake8 --max-line-length=120 --ignore=F401,W503 --count --show-source --statistics orsopy
+          flake8 --max-line-length=120 --ignore=F401,W503 --count --show-source --statistics tests
       
       - name: Test with coverage
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,4 +1,4 @@
-name: Package Testing
+name: Package Formatt
 
 on:
   - push
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
+          pip install pytest
           if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
 
       - name: Install orsopy
@@ -33,11 +33,6 @@ jobs:
         run: |
           pytest
 
-      - name: Lint
-        run: |
-          flake8 --max-line-length=120 --ignore=F401,W503 --count --show-source --statistics orsopy
-          flake8 --max-line-length=120 --ignore=F401,W503 --count --show-source --statistics tests
-      
       - name: Test with coverage
         run: |
           coverage run -m pytest
@@ -74,8 +69,3 @@ jobs:
       - name: Test with pytest
         run: |
           pytest
-
-      - name: Lint
-        run: |
-          flake8 --ignore=F401,E501 --count --show-source --statistics orsopy
-          flake8 --ignore=F401,E501 --count --show-source --statistics tests

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,4 +1,4 @@
-name: Package Formatt
+name: Unit Testing
 
 on:
   - push

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -76,12 +76,12 @@ Ready to contribute? Here's how to set up `orsopy` for local development.
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8 and the
-   tests, including testing other Python versions with tox::
+5. When you're done making changes, auto format the code and check that your changes pass the unit
+   tests::
 
-    $ flake8 orsopy tests
+    $ black -l 120 orsopy tests
+    $ isort -l 120 --lbt 1 orsopy tests
     $ python setup.py test or pytest
-    $ tox
 
    To get flake8 and tox, just pip install them into your virtualenv.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -81,7 +81,7 @@ Ready to contribute? Here's how to set up `orsopy` for local development.
 
     $ black -l 120 orsopy tests
     $ isort -l 120 --lbt 1 orsopy tests
-    $ python setup.py test or pytest
+    $ pytest
 
    To get flake8 and tox, just pip install them into your virtualenv.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -77,10 +77,11 @@ Ready to contribute? Here's how to set up `orsopy` for local development.
    Now you can make your changes locally.
 
 5. When you're done making changes, auto format the code and check that your changes pass the unit
-   tests::
+   tests and confirms to PEP 8::
 
     $ black -l 120 orsopy tests
     $ isort -l 120 --lbt 1 orsopy tests
+    $ flake8 --max-line-length=120 --ignore=F401,W503 --count --show-source --statistics orsopy tests
     $ pytest
 
    To get flake8 and tox, just pip install them into your virtualenv.

--- a/orsopy/__init__.py
+++ b/orsopy/__init__.py
@@ -1,5 +1,5 @@
 """Top-level package for orsopy."""
 
 __author__ = """Andrew R. McCluskey"""
-__email__ = 'andrew.mccluskey@ess.eu'
-__version__ = '0.0.3'
+__email__ = "andrew.mccluskey@ess.eu"
+__version__ = "0.0.3"

--- a/orsopy/__init__.py
+++ b/orsopy/__init__.py
@@ -1,5 +1,3 @@
 """Top-level package for orsopy."""
 
-__author__ = """Andrew R. McCluskey"""
-__email__ = "andrew.mccluskey@ess.eu"
 __version__ = "0.0.3"

--- a/orsopy/fileio/__init__.py
+++ b/orsopy/fileio/__init__.py
@@ -1,14 +1,10 @@
 """
 Implementation of the Orso class that defined the header.
 """
-from .base import (Header, Column, Person, ValueRange, ValueVector, Value,
-                   File, _read_header_data, _validate_header_data)
-from .data_source import (DataSource, Experiment, Sample, InstrumentSettings,
-                          Measurement)
+
+from .base import Column, File, Header, Person, Value, ValueRange, ValueVector, _read_header_data, _validate_header_data
+from .data_source import DataSource, Experiment, InstrumentSettings, Measurement, Sample
+from .orso import ORSO_VERSION, Orso, OrsoDataset, load_orso, save_orso
 from .reduction import Reduction, Software
-from .orso import Orso, OrsoDataset, save_orso, load_orso, ORSO_VERSION
-
-# author: Andrew R. McCluskey (arm61)
-
 
 __all__ = [s for s in dir() if not s.startswith("_")]

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -66,9 +66,7 @@ def _custom_init_fn(fieldsarg, frozen, has_post_init, self_name, globals):
                 raise TypeError(f"non-default argument {f.name!r} " "follows default argument")
 
     locals = {f"_type_{f.name}": f.type for f in fieldsarg}
-    locals.update(
-        {"MISSING": MISSING, "_HAS_DEFAULT_FACTORY": _HAS_DEFAULT_FACTORY,}
-    )
+    locals.update({"MISSING": MISSING, "_HAS_DEFAULT_FACTORY": _HAS_DEFAULT_FACTORY})
 
     body_lines = []
     for f in fieldsarg:

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -4,7 +4,6 @@ Implementation of the base classes for the ORSO header.
 
 import datetime
 import json
-# author: Andrew R. McCluskey (arm61)
 import os.path
 import pathlib
 import re

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -2,25 +2,25 @@
 Implementation of the base classes for the ORSO header.
 """
 
+import datetime
+import json
 # author: Andrew R. McCluskey (arm61)
 import os.path
-from copy import deepcopy
-from collections.abc import Mapping
-from typing import Optional, Union, List, Tuple, TextIO, Generator, Any
-from inspect import isclass
-from dataclasses import field, dataclass, fields, \
-    _set_new_attribute, _field_init, _create_fn, _init_param, \
-    _FIELD, _FIELDS, _FIELD_INITVAR, MISSING, _HAS_DEFAULT_FACTORY, _POST_INIT_NAME
-import datetime
 import pathlib
-import warnings
-import json
-import yaml
-import yaml.constructor
-from contextlib import contextmanager
 import re
+import warnings
+
+from collections.abc import Mapping
+from contextlib import contextmanager
+from copy import deepcopy
+from dataclasses import (_FIELD, _FIELD_INITVAR, _FIELDS, _HAS_DEFAULT_FACTORY, _POST_INIT_NAME, MISSING, _create_fn,
+                         _field_init, _init_param, _set_new_attribute, dataclass, field, fields)
+from inspect import isclass
+from typing import Any, Generator, List, Optional, TextIO, Tuple, Union
 
 import numpy as np
+import yaml
+import yaml.constructor
 
 # typing stuff introduced in python 3.8
 try:
@@ -47,8 +47,9 @@ def __datetime_representer(dumper, data):
 yaml.add_representer(datetime.datetime, __datetime_representer)
 
 # make sure that datetime strings get loaded as str not datetime instances
-yaml.constructor.SafeConstructor.yaml_constructors[u'tag:yaml.org,2002:timestamp'] = (
-    yaml.constructor.SafeConstructor.yaml_constructors[u'tag:yaml.org,2002:str'])
+yaml.constructor.SafeConstructor.yaml_constructors[
+    "tag:yaml.org,2002:timestamp"
+] = yaml.constructor.SafeConstructor.yaml_constructors["tag:yaml.org,2002:str"]
 
 
 def _custom_init_fn(fieldsarg, frozen, has_post_init, self_name, globals):
@@ -62,14 +63,12 @@ def _custom_init_fn(fieldsarg, frozen, has_post_init, self_name, globals):
             if not (f.default is MISSING and f.default_factory is MISSING):
                 seen_default = True
             elif seen_default:
-                raise TypeError(f'non-default argument {f.name!r} '
-                                'follows default argument')
+                raise TypeError(f"non-default argument {f.name!r} " "follows default argument")
 
-    locals = {f'_type_{f.name}': f.type for f in fieldsarg}
-    locals.update({
-        'MISSING': MISSING,
-        '_HAS_DEFAULT_FACTORY': _HAS_DEFAULT_FACTORY,
-    })
+    locals = {f"_type_{f.name}": f.type for f in fieldsarg}
+    locals.update(
+        {"MISSING": MISSING, "_HAS_DEFAULT_FACTORY": _HAS_DEFAULT_FACTORY,}
+    )
 
     body_lines = []
     for f in fieldsarg:
@@ -78,50 +77,49 @@ def _custom_init_fn(fieldsarg, frozen, has_post_init, self_name, globals):
             body_lines.append(line)
 
     if has_post_init:
-        params_str = ','.join(f.name for f in fieldsarg
-                              if f._field_type is _FIELD_INITVAR)
-        body_lines.append(f'{self_name}.{_POST_INIT_NAME}({params_str})')
+        params_str = ",".join(f.name for f in fieldsarg if f._field_type is _FIELD_INITVAR)
+        body_lines.append(f"{self_name}.{_POST_INIT_NAME}({params_str})")
 
     # processing of additional user keyword arguments
-    body_lines += ['for k,v in user_kwds.items():', '    setattr(self, k, v)']
+    body_lines += ["for k,v in user_kwds.items():", "    setattr(self, k, v)"]
 
-    return _create_fn('__init__',
-                      [self_name] + [_init_param(f) for f in fieldsarg if f.init] + ['**user_kwds'],
-                      body_lines,
-                      locals=locals,
-                      globals=globals,
-                      return_type=None)
+    return _create_fn(
+        "__init__",
+        [self_name] + [_init_param(f) for f in fieldsarg if f.init] + ["**user_kwds"],
+        body_lines,
+        locals=locals,
+        globals=globals,
+        return_type=None,
+    )
 
 
 def orsodataclass(cls: type):
     attrs = cls.__dict__
     bases = cls.__bases__
-    if '__annotations__' in attrs and \
-            len([k for k in attrs['__annotations__'].keys() if not k.startswith('_')]) > 0:
+    if "__annotations__" in attrs and len([k for k in attrs["__annotations__"].keys() if not k.startswith("_")]) > 0:
         # only applies to dataclass children of Header
         # add optional comment attribute, needs to come last
-        attrs['__annotations__']['comment'] = Optional[str]
-        setattr(cls, 'comment', field(default=None))
+        attrs["__annotations__"]["comment"] = Optional[str]
+        setattr(cls, "comment", field(default=None))
 
         # create the _orso_optional attribute
         orso_optionals = []
-        for fname, ftype in attrs['__annotations__'].items():
+        for fname, ftype in attrs["__annotations__"].items():
             if type(None) in get_args(ftype):
                 orso_optionals.append(fname)
         for base in bases:
-            if hasattr(base, '_orso_optionals'):
-                orso_optionals += getattr(base, '_orso_optionals')
-        setattr(cls, '_orso_optionals', orso_optionals)
+            if hasattr(base, "_orso_optionals"):
+                orso_optionals += getattr(base, "_orso_optionals")
+        setattr(cls, "_orso_optionals", orso_optionals)
         out = dataclass(cls, repr=False, init=False)
         fieldsarg = getattr(out, _FIELDS)
 
         # Generate custom __init__ method that allows arbitrary extra keyword arguments
         has_post_init = hasattr(out, _POST_INIT_NAME)
         # Include InitVars and regular fields (so, not ClassVars).
-        flds = [f for f in fieldsarg.values()
-                if f._field_type in (_FIELD, _FIELD_INITVAR)]
-        init_fun = _custom_init_fn(flds, False, has_post_init, 'self', globals())
-        _set_new_attribute(out, '__init__', init_fun)
+        flds = [f for f in fieldsarg.values() if f._field_type in (_FIELD, _FIELD_INITVAR)]
+        init_fun = _custom_init_fn(flds, False, has_post_init, "self", globals())
+        _set_new_attribute(out, "__init__", init_fun)
 
         return out
     else:
@@ -152,12 +150,12 @@ class Header:
                         f"No suitable conversion found for {fld.name}, "
                         f"{fld.type} with value {attr}, "
                         "setting attribute with raw value from ORSO file",
-                        RuntimeWarning
+                        RuntimeWarning,
                     )
                     setattr(self, fld.name, attr)
                     # raise ValueError(f"No suitable conversion found for {fld.type} with value {attr}")
 
-        if hasattr(self, 'unit'):
+        if hasattr(self, "unit"):
             self._check_unit(self.unit)
 
     @property
@@ -185,7 +183,7 @@ class Header:
         :return: Correctly resolved object with required type for orso
             compatibility.
         """
-        if isclass(hint) and not getattr(hint, '__origin__', None) in [List, Tuple, Union, Literal]:
+        if isclass(hint) and not getattr(hint, "__origin__", None) in [List, Tuple, Union, Literal]:
             # simple type that we can work with, no Union or List/Dict
             if isinstance(item, hint):
                 return item
@@ -195,8 +193,8 @@ class Header:
                     return datetime.datetime.fromisoformat(item)
                 except AttributeError:  # python 3.6
                     try:
-                        item = item.split('+', 1)[0]
-                        if '.' in item:
+                        item = item.split("+", 1)[0]
+                        if "." in item:
                             return datetime.datetime.strptime(item, "%Y-%m-%dT%H:%M:%S.%f")
                         else:
                             return datetime.datetime.strptime(item, "%Y-%m-%dT%H:%M:%S")
@@ -209,17 +207,13 @@ class Header:
             if issubclass(hint, Header):
                 # convert to dataclass instance
                 attribs = hint.__annotations__.keys()
-                realised_items = {
-                    k: item[k] for k in item.keys() if k in attribs
-                }
+                realised_items = {k: item[k] for k in item.keys() if k in attribs}
                 # orphan_items are extra dictionary entries that don't correspond to
                 # arguments of a Header instance. They can't be used to construct
                 # a header instance, so remove them from the dict of arguments.
                 # This enables back compatibility of Orso files as attributes
                 # present in later versions will still be loadable by earlier code.
-                orphan_items = {
-                    k: item[k] for k in item.keys() if k not in attribs
-                }
+                orphan_items = {k: item[k] for k in item.keys() if k not in attribs}
 
                 try:
                     value = hint(**realised_items)
@@ -241,9 +235,7 @@ class Header:
             if hbase in (list, tuple):
                 t0 = get_args(hint)[0]
                 if isinstance(item, (list, tuple)):
-                    return type(item)(
-                        [Header._resolve_type(t0, i) for i in item]
-                    )
+                    return type(item)([Header._resolve_type(t0, i) for i in item])
                 else:
                     return [Header._resolve_type(t0, item)]
             elif hbase in [Union, Optional]:
@@ -263,7 +255,7 @@ class Header:
         return None
 
     @classmethod
-    def empty(cls) -> 'Header':
+    def empty(cls) -> "Header":
         """
         Create an empty instance of this item containing
         all non-option attributes as :code:`None`.
@@ -279,15 +271,18 @@ class Header:
                 attr_items[fld.name] = fld.type.empty()
             elif get_origin(fld.type) is Union and issubclass(get_args(fld.type)[0], Header):
                 attr_items[fld.name] = get_args(fld.type)[0].empty()
-            elif get_origin(fld.type) is list and isclass(get_args(fld.type)[0]) \
-                    and issubclass(get_args(fld.type)[0], Header):
+            elif (
+                get_origin(fld.type) is list
+                and isclass(get_args(fld.type)[0])
+                and issubclass(get_args(fld.type)[0], Header)
+            ):
                 attr_items[fld.name] = [get_args(fld.type)[0].empty()]
             else:
                 attr_items[fld.name] = None
         return cls(**attr_items)
 
     @staticmethod
-    def asdict(header: 'Header') -> dict:
+    def asdict(header: "Header") -> dict:
         """
         Static method for :py:func:`to_dict`.
 
@@ -306,9 +301,7 @@ class Header:
         """
         out_dict = {}
         for i, value in self.__dict__.items():
-            if i.startswith("_") or (
-                    value is None and i in self._orso_optionals
-            ):
+            if i.startswith("_") or (value is None and i in self._orso_optionals):
                 continue
 
             if hasattr(value, "to_dict"):
@@ -347,19 +340,19 @@ class Header:
         """
         if unit is not None:
             # raise UnicodeError if not ascii
-            unit.encode('ascii')
+            unit.encode("ascii")
 
     def __repr__(self):
         """
         Representation that does not show empty arguments.
         """
-        out = f'{self.__class__.__name__}('
+        out = f"{self.__class__.__name__}("
         for fi in fields(self):
             if fi.name in self._orso_optionals and getattr(self, fi.name) is None:
                 # ignore empty optional arguments
                 continue
-            out += f'{fi.name}={getattr(self, fi.name)!r}, '
-        out = out[:-2] + ')'
+            out += f"{fi.name}={getattr(self, fi.name)!r}, "
+        out = out[:-2] + ")"
         return out
 
     def _staggered_repr(self):
@@ -370,16 +363,16 @@ class Header:
         To use in a subclass, the __repr__ method has to be replaced with this one.
         """
         slen = len(self.__class__.__name__)
-        out = f'{self.__class__.__name__}(\n'
+        out = f"{self.__class__.__name__}(\n"
         for fi in fields(self):
             if fi.name in self._orso_optionals and getattr(self, fi.name) is None:
                 # ignore empty optional arguments
                 continue
             nlen = len(fi.name)
             ftxt = repr(getattr(self, fi.name))
-            ftxt = ftxt.replace('\n', '\n' + ' ' * (slen + nlen + 2))
-            out += ' ' * (slen + 1) + f'{fi.name}={ftxt},\n'
-        out += ' ' * (slen + 1) + ')'
+            ftxt = ftxt.replace("\n", "\n" + " " * (slen + nlen + 2))
+            out += " " * (slen + 1) + f"{fi.name}={ftxt},\n"
+        out += " " * (slen + 1) + ")"
         return out
 
 
@@ -390,9 +383,7 @@ class Value(Header):
     """
 
     magnitude: Union[float, List[float]]
-    unit: Optional[str] = field(
-        default=None, metadata={"description": "SI unit string"}
-    )
+    unit: Optional[str] = field(default=None, metadata={"description": "SI unit string"})
 
 
 @orsodataclass
@@ -403,9 +394,7 @@ class ValueRange(Header):
 
     min: Union[float, List[float]]
     max: Union[float, List[float]]
-    unit: Optional[str] = field(
-        default=None, metadata={"description": "SI unit string"}
-    )
+    unit: Optional[str] = field(default=None, metadata={"description": "SI unit string"})
 
 
 @orsodataclass
@@ -426,9 +415,7 @@ class ValueVector(Header):
     x: Union[float, List[float]]
     y: Union[float, List[float]]
     z: Union[float, List[float]]
-    unit: Optional[str] = field(
-        default=None, metadata={"description": "SI unit string"}
-    )
+    unit: Optional[str] = field(default=None, metadata={"description": "SI unit string"})
 
 
 @orsodataclass
@@ -440,9 +427,7 @@ class Person(Header):
 
     name: str
     affiliation: Union[str, List[str]]
-    contact: Optional[str] = field(
-        default=None, metadata={"description": "Contact (email) address"}
-    )
+    contact: Optional[str] = field(default=None, metadata={"description": "Contact (email) address"})
 
 
 @orsodataclass
@@ -452,12 +437,8 @@ class Column(Header):
     """
 
     name: str
-    unit: Optional[str] = field(
-        default=None, metadata={"description": "SI unit string"}
-    )
-    dimension: Optional[str] = field(
-        default=None, metadata={"dimension": "A description of the column"}
-    )
+    unit: Optional[str] = field(default=None, metadata={"description": "SI unit string"})
+    dimension: Optional[str] = field(default=None, metadata={"dimension": "A description of the column"})
 
 
 @orsodataclass
@@ -471,8 +452,8 @@ class File(Header):
         default=None,
         metadata={
             "description": "Last modified timestamp. If it's not specified,"
-                           " then an attempt will be made to check on the file"
-                           " itself"
+            " then an attempt will be made to check on the file"
+            " itself"
         },
     )
 
@@ -484,9 +465,7 @@ class File(Header):
         if self.timestamp is None:
             fname = pathlib.Path(self.file)
             if fname.exists():
-                self.timestamp = datetime.datetime.fromtimestamp(
-                    fname.stat().st_mtime
-                )
+                self.timestamp = datetime.datetime.fromtimestamp(fname.stat().st_mtime)
 
 
 def _read_header_data(file: Union[TextIO, str], validate: bool = False) -> Tuple[List[dict], list, str]:
@@ -520,7 +499,7 @@ def _read_header_data(file: Union[TextIO, str], validate: bool = False) -> Tuple
         for i, line in enumerate(fi.readlines()):
             if not line.startswith("#"):
                 # ignore empty lines
-                if line.strip() != '':
+                if line.strip() != "":
                     _ds_lines.append(line)
                 continue
 
@@ -531,9 +510,7 @@ def _read_header_data(file: Union[TextIO, str], validate: bool = False) -> Tuple
                 # a new dataset is starting. Complete the previous dataset's
                 # numerical array  and start collecting the numbers for this
                 # dataset
-                _d = np.array(
-                    [np.fromstring(v, dtype=float, sep=" ") for v in _ds_lines]
-                )
+                _d = np.array([np.fromstring(v, dtype=float, sep=" ") for v in _ds_lines])
                 data.append(_d)
                 _ds_lines = []
 
@@ -546,9 +523,7 @@ def _read_header_data(file: Union[TextIO, str], validate: bool = False) -> Tuple
                 header.append(line[1:])
 
         # append the last numerical array
-        _d = np.array(
-            [np.fromstring(v, dtype=float, sep=" ") for v in _ds_lines]
-        )
+        _d = np.array([np.fromstring(v, dtype=float, sep=" ") for v in _ds_lines])
         data.append(_d)
 
         yml = "".join(header)
@@ -560,9 +535,7 @@ def _read_header_data(file: Union[TextIO, str], validate: bool = False) -> Tuple
         )
 
         if not pattern.match(header[0].lstrip(" ")):
-            raise ValueError(
-                "First line does not appear to match that of an ORSO file"
-            )
+            raise ValueError("First line does not appear to match that of an ORSO file")
         version = re.findall(r"([0-9]+\.?[0-9]*|\.[0-9]+)+?", header[0])[0]
 
         dcts = yaml.safe_load_all(yml)
@@ -597,6 +570,7 @@ def _validate_header_data(dct_list: List[dict]):
         :code:`'sQz'` are not the same.
     """
     import jsonschema
+
     req_cols = ["Qz", "R", "sR", "sQz"]
     acceptable_Qz_units = ["1/angstrom", "1/nm"]
 
@@ -615,8 +589,8 @@ def _validate_header_data(dct_list: List[dict]):
         cols = dct["columns"]
 
         ncols = min(4, len(cols))
-        col_names = [col['name'] for col in cols]
-        units = [col.get('unit') for col in cols]
+        col_names = [col["name"] for col in cols]
+        units = [col.get("unit") for col in cols]
 
         # If dct was created with Orso.empty() the Orso.columns attribute
         # will be [{"name": None}]. In which case don't both validating column
@@ -625,14 +599,10 @@ def _validate_header_data(dct_list: List[dict]):
             continue
 
         if col_names[:ncols] != req_cols[:ncols]:
-            raise ValueError(
-                "The first four columns should be named"
-                " 'Qz', 'R', ['sR', ['sQz']]"
-            )
+            raise ValueError("The first four columns should be named" " 'Qz', 'R', ['sR', ['sQz']]")
 
         if units[0] not in acceptable_Qz_units:
-            raise ValueError("The Qz column must have units of '1/angstrom'"
-                             " or '1/nm'")
+            raise ValueError("The Qz column must have units of '1/angstrom'" " or '1/nm'")
 
         if len(units) >= 4 and units[0] != units[3]:
             raise ValueError("Columns Qz and sQz must have the same units'")
@@ -685,9 +655,11 @@ def _todict(obj: Any, classkey: Any = None) -> dict:
         return [_todict(v, classkey) for v in obj]
     elif hasattr(obj, "__dict__"):
         data = dict(
-            [(key, _todict(value, classkey)) for key, value
-             in obj.__dict__.items()
-             if not callable(value) and not key.startswith('_')]
+            [
+                (key, _todict(value, classkey))
+                for key, value in obj.__dict__.items()
+                if not callable(value) and not key.startswith("_")
+            ]
         )
 
         if classkey is not None and hasattr(obj, "__class__"):

--- a/orsopy/fileio/data_source.py
+++ b/orsopy/fileio/data_source.py
@@ -2,10 +2,7 @@
 Implementation of the data_source for the ORSO header.
 """
 
-# author: Andrew R. McCluskey (arm61)
-
-from dataclasses import dataclass, field
-# import enum
+from dataclasses import field
 from typing import Dict, List, Optional, Union
 
 from .base import File, Header, Person, Value, ValueRange, ValueVector, orsodataclass

--- a/orsopy/fileio/data_source.py
+++ b/orsopy/fileio/data_source.py
@@ -4,11 +4,11 @@ Implementation of the data_source for the ORSO header.
 
 # author: Andrew R. McCluskey (arm61)
 
+from dataclasses import dataclass, field
 # import enum
-from typing import Optional, Dict, List, Union
-from dataclasses import field, dataclass
+from typing import Dict, List, Optional, Union
 
-from .base import orsodataclass, File, Header, ValueRange, Value, ValueVector, Person
+from .base import File, Header, Person, Value, ValueRange, ValueVector, orsodataclass
 
 # typing stuff introduced in python 3.8
 try:
@@ -32,10 +32,11 @@ class Experiment(Header):
     :param doi: Digital object identifier for the experiment, possibly
         provided by the facility.
     """
+
     title: str
     instrument: str
     start_date: str
-    probe: Union[Literal['neutrons', 'x-rays']]
+    probe: Union[Literal["neutrons", "x-rays"]]
     facility: Optional[str] = None
     proposalID: Optional[str] = None
     doi: Optional[str] = None
@@ -59,17 +60,15 @@ class Sample(Header):
     :param environment: Name of the sample environment device(s).
     :param sample_parameters: Dictionary of sample parameters.
     """
+
     name: str
     category: Optional[str] = None
     composition: Optional[str] = None
     description: Optional[Union[str, List[str]]] = None
     environment: Optional[Union[str, List[str]]] = None
     sample_parameters: Optional[Dict] = field(
-        default=None,
-        metadata={
-            'description':
-                'Using keys for parameters and Value* objects for values.'
-        })
+        default=None, metadata={"description": "Using keys for parameters and Value* objects for values."}
+    )
 
 
 # Enum does not work with yaml, if we really want this it has to be handle
@@ -105,29 +104,16 @@ class InstrumentSettings(Header):
     :param configuration: Description of the instreument configuration (full
         polarized/liquid surface/etc).
     """
+
     incident_angle: Union[Value, ValueRange]
     wavelength: Union[Value, ValueRange]
-    polarization: Optional[
-        Union[
-            Literal[
-                'unpolarized',
-                'p',
-                'm',
-                'mm',
-                'mp',
-                'pm',
-                'pp'], ValueVector]] = field(
-        default='unpolarized',
-        metadata={
-            'description':
-                'Polarization described as unpolarized/ p '
-                '/ m / pp / pm / mp / mm / vector'
-        })
+    polarization: Optional[Union[Literal["unpolarized", "p", "m", "mm", "mp", "pm", "pp"], ValueVector]] = field(
+        default="unpolarized",
+        metadata={"description": "Polarization described as unpolarized/ p " "/ m / pp / pm / mp / mm / vector"},
+    )
     configuration: Optional[str] = field(
-        default=None,
-        metadata={
-            'description': 'half / full polarized | liquid_surface | etc'
-        })
+        default=None, metadata={"description": "half / full polarized | liquid_surface | etc"}
+    )
 
     __repr__ = Header._staggered_repr
 
@@ -143,15 +129,11 @@ class Measurement(Header):
     :param scheme: Measurement scheme (one of :code:`'angle-dispersive'`,
         :code:`'energy-dispersive'`/:code:`'angle- and energy-dispersive'`).
     """
+
     instrument_settings: InstrumentSettings
     data_files: List[Union[File, str]]
     references: Optional[List[Union[File, str]]] = None
-    scheme: Optional[
-        Union[
-            Literal[
-                'angle- and energy-dispersive',
-                'angle-dispersive',
-                'energy-dispersive']]] = None
+    scheme: Optional[Union[Literal["angle- and energy-dispersive", "angle-dispersive", "energy-dispersive"]]] = None
 
     __repr__ = Header._staggered_repr
 
@@ -168,6 +150,7 @@ class DataSource(Header):
     :param sample: Sample information.
     :param measurement: Measurement specifics.
     """
+
     owner: Person
     experiment: Experiment
     sample: Sample

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -2,8 +2,6 @@
 Implementation of the top level class for the ORSO header.
 """
 
-# author: Andrew R. McCluskey (arm61)
-
 from dataclasses import dataclass
 from typing import Any, List, Optional, TextIO, Union
 

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -4,20 +4,20 @@ Implementation of the top level class for the ORSO header.
 
 # author: Andrew R. McCluskey (arm61)
 
-import yaml
-from typing import List, Union, TextIO, Optional, Any
 from dataclasses import dataclass
-from .base import (orsodataclass, Header, Column, _possibly_open_file,
-                   _read_header_data, _nested_update, _dict_diff)
+from typing import Any, List, Optional, TextIO, Union
+
+import numpy as np
+import yaml
+
+from .base import Column, Header, _dict_diff, _nested_update, _possibly_open_file, _read_header_data, orsodataclass
 from .data_source import DataSource
 from .reduction import Reduction
 
-import numpy as np
-
-
-ORSO_VERSION = '0.1'
-ORSO_DESIGNATE = (f"# ORSO reflectivity data file | {ORSO_VERSION} standard "
-                  "| YAML encoding | https://www.reflectometry.org/")
+ORSO_VERSION = "0.1"
+ORSO_DESIGNATE = (
+    f"# ORSO reflectivity data file | {ORSO_VERSION} standard " "| YAML encoding | https://www.reflectometry.org/"
+)
 
 
 @orsodataclass
@@ -35,6 +35,7 @@ class Orso(Header):
     :param data_set: An identified for the data set, i.e. if there is
         more than one data set in the object.
     """
+
     data_source: DataSource
     reduction: Reduction
     columns: List[Column]
@@ -42,8 +43,14 @@ class Orso(Header):
 
     __repr__ = Header._staggered_repr
 
-    def __init__(self, data_source: DataSource, reduction: Reduction,
-                 columns: List[Column], data_set: Optional[Union[int, str]] = None, **user_data):
+    def __init__(
+        self,
+        data_source: DataSource,
+        reduction: Reduction,
+        columns: List[Column],
+        data_set: Optional[Union[int, str]] = None,
+        **user_data,
+    ):
         self.data_source = data_source
         self.reduction = reduction
         self.columns = columns
@@ -70,7 +77,7 @@ class Orso(Header):
 
         :return: Explanatory string.
         """
-        out = '# '
+        out = "# "
         for ci in self.columns:
             if ci.unit is None:
                 out += f"{ci.name:<23}"
@@ -81,7 +88,7 @@ class Orso(Header):
                 out = out[:-4]
         return out[:-1]
 
-    def from_difference(self, other_dict: dict) -> 'Orso':
+    def from_difference(self, other_dict: dict) -> "Orso":
         """
         Constructs another :py:class:`Orso` instance from self, and a dict
         containing updated header information.
@@ -96,7 +103,7 @@ class Orso(Header):
         output = _nested_update(output, other_dict)
         return Orso(**output)
 
-    def to_difference(self, other: 'Orso') -> dict:
+    def to_difference(self, other: "Orso") -> dict:
         """
         A dictionary containing the difference in header information between
         two :py:class:`Orso` objects.
@@ -118,8 +125,8 @@ class Orso(Header):
         out = super().to_dict()
         out.update(self._user_data)
         # put columns at the end of the dictionary
-        cols = out.pop('columns')
-        out['columns'] = cols
+        cols = out.pop("columns")
+        out["columns"] = cols
         return out
 
 
@@ -132,6 +139,7 @@ class OrsoDataset:
 
     :raises ValueError: When :code:`ncols != len(self.info.columns)`.
     """
+
     info: Orso
     data: Any
 
@@ -149,7 +157,7 @@ class OrsoDataset:
         out += self.info.column_header()
         return out
 
-    def diff_header(self, other: 'OrsoDataset') -> str:
+    def diff_header(self, other: "OrsoDataset") -> str:
         """
         Return a header string that only contains changes to other
         :py:class:`OrsoDataset` ensure that data_set is the first entry.
@@ -176,15 +184,13 @@ class OrsoDataset:
         """
         return save_orso([self], fname)
 
-    def __eq__(self, other: 'OrsoDataset'):
+    def __eq__(self, other: "OrsoDataset"):
         return self.info == other.info and (self.data == other.data).all()
 
 
 def save_orso(
-        datasets: List[OrsoDataset],
-        fname: Union[TextIO, str],
-        comment: Optional[str] = None,
-        data_separator: str = '') -> None:
+    datasets: List[OrsoDataset], fname: Union[TextIO, str], comment: Optional[str] = None, data_separator: str = ""
+) -> None:
     """
     Saves an ORSO file. Each of the datasets must have a unique
     :py:attr:`OrsoDataset.info.data_set` attribute. If that attribute is not
@@ -200,35 +206,34 @@ def save_orso(
         values are not unique.
     """
     # check for valid seperator characters
-    if data_separator != '' and not data_separator.isspace():
+    if data_separator != "" and not data_separator.isspace():
         raise ValueError("data_separator can only contain new lines and spaces")
 
     for idx, dataset in enumerate(datasets):
         info = dataset.info
         data_set = info.data_set
-        if (data_set is None or (isinstance(data_set, str) and len(data_set) == 0)):
+        if data_set is None or (isinstance(data_set, str) and len(data_set) == 0):
             # it's not set, or is zero length string
             info.data_set = idx
 
     dsets = [dataset.info.data_set for dataset in datasets]
     if len(set(dsets)) != len(dsets):
-        raise ValueError(
-            "All `OrsoDataset.info.data_set` values must be unique")
+        raise ValueError("All `OrsoDataset.info.data_set` values must be unique")
 
-    with _possibly_open_file(fname, 'w') as f:
+    with _possibly_open_file(fname, "w") as f:
         header = f"{ORSO_DESIGNATE}\n"
         if comment is not None:
             header += f"# {comment}\n"
 
         ds1 = datasets[0]
         header += ds1.header()
-        np.savetxt(f, ds1.data, header=header, fmt='%-22.16e')
+        np.savetxt(f, ds1.data, header=header, fmt="%-22.16e")
 
         for dsi in datasets[1:]:
             # write an optional spacer string between dataset e.g. \n
             f.write(data_separator)
             hi = ds1.diff_header(dsi)
-            np.savetxt(f, dsi.data, header=hi, fmt='%-22.16e')
+            np.savetxt(f, dsi.data, header=hi, fmt="%-22.16e")
 
 
 def load_orso(fname: Union[TextIO, str]) -> List[OrsoDataset]:

--- a/orsopy/fileio/reduction.py
+++ b/orsopy/fileio/reduction.py
@@ -2,8 +2,6 @@
 The reduction elements for the ORSO header
 """
 
-# author: Andrew R. McCluskey (arm61)
-
 import datetime
 
 from dataclasses import field

--- a/orsopy/fileio/reduction.py
+++ b/orsopy/fileio/reduction.py
@@ -4,10 +4,12 @@ The reduction elements for the ORSO header
 
 # author: Andrew R. McCluskey (arm61)
 
-from typing import Optional, List, Union
-from dataclasses import field
 import datetime
-from .base import orsodataclass, Header, Person
+
+from dataclasses import field
+from typing import List, Optional, Union
+
+from .base import Header, Person, orsodataclass
 
 
 @orsodataclass
@@ -19,6 +21,7 @@ class Software(Header):
     :param version: Version identified for the software.
     :param platform: Operating system.
     """
+
     name: str
     version: Optional[str] = None
     platform: Optional[str] = None
@@ -37,23 +40,16 @@ class Reduction(Header):
     :param script: Path to reduction script or notebook.
     :param binary: Path to full reduction information file.
     """
+
     software: Union[Software, str]
     timestamp: Optional[datetime.datetime] = field(
-        default=None,
-        metadata={
-            "description": "Timestamp string, formatted as ISO 8601 datetime"
-        })
+        default=None, metadata={"description": "Timestamp string, formatted as ISO 8601 datetime"}
+    )
     creator: Optional[Person] = None
     corrections: Optional[List[str]] = None
-    computer: Optional[str] = field(
-        default=None, metadata={'description': 'Computer used for reduction'})
-    call: Optional[str] = field(
-        default=None, metadata={'description': 'The command line call used'})
-    script: Optional[str] = field(
-        default=None,
-        metadata={'description': 'Path to reduction script or notebook'})
-    binary: Optional[str] = field(
-        default=None,
-        metadata={'description': 'Path to full information file'})
+    computer: Optional[str] = field(default=None, metadata={"description": "Computer used for reduction"})
+    call: Optional[str] = field(default=None, metadata={"description": "The command line call used"})
+    script: Optional[str] = field(default=None, metadata={"description": "Path to reduction script or notebook"})
+    binary: Optional[str] = field(default=None, metadata={"description": "Path to full information file"})
 
     __repr__ = Header._staggered_repr

--- a/orsopy/fileio/typing_backport.py
+++ b/orsopy/fileio/typing_backport.py
@@ -2,19 +2,21 @@
 Module for compatibility with Python <3.8. Requires
 the typing_extensions module to be installed.
 """
+
 from typing import List, Tuple
+
 from typing_extensions import Literal
 
 
 def get_args(annotation):
     if annotation.__class__ is Literal.__class__:
         return annotation.__values__
-    return getattr(annotation, '__args__', ())
+    return getattr(annotation, "__args__", ())
 
 
 def get_origin(annotation):
     atype = type(annotation)
-    if hasattr(annotation, '__origin__'):
+    if hasattr(annotation, "__origin__"):
         orig = annotation.__origin__
         if orig is List:
             return list

--- a/tests/test_fileio/test_base.py
+++ b/tests/test_fileio/test_base.py
@@ -1,15 +1,15 @@
 """
 Tests for fileio.base module
 """
-
-# author: Andrew R. McCluskey (arm61)
 # pylint: disable=R0201
 
-from datetime import datetime
-import unittest
-import warnings
 import pathlib
+import unittest
+
+from datetime import datetime
+
 from numpy.testing import assert_equal
+
 from orsopy.fileio import base
 
 
@@ -17,263 +17,260 @@ class TestValue(unittest.TestCase):
     """
     Testing the Value class.
     """
+
     def test_single_value(self):
         """
         Creation of an object with a magnitude and unit.
         """
-        value = base.Value(1., 'm')
-        assert value.magnitude == 1.
-        assert value.unit == 'm'
+        value = base.Value(1.0, "m")
+        assert value.magnitude == 1.0
+        assert value.unit == "m"
 
     def test_list(self):
         """
         Creation of an object with a a list of values and a unit.
         """
-        value = base.Value([1, 2, 3], 'm')
+        value = base.Value([1, 2, 3], "m")
         assert_equal(value.magnitude, [1, 2, 3])
-        assert value.unit == 'm'
+        assert value.unit == "m"
 
     def test_bad_unit(self):
         """
         Rejection of non-ASCII units.
         """
         with self.assertRaises(ValueError):
-            _ = base.Value(1., 'Å')
+            _ = base.Value(1.0, "Å")
 
     def test_to_yaml(self):
         """
         Transform to yaml.
         """
-        value = base.Value(1., 'm')
-        assert value.to_yaml() == 'magnitude: 1.0\nunit: m\n'
+        value = base.Value(1.0, "m")
+        assert value.to_yaml() == "magnitude: 1.0\nunit: m\n"
 
     def test_no_magnitude_to_yaml(self):
         """
         Transform to yaml with a non-optional ORSO item.
         """
         value = base.Value(None)
-        assert value.to_yaml() == 'magnitude: null\n'
+        assert value.to_yaml() == "magnitude: null\n"
 
 
 class TestValueVector(unittest.TestCase):
     """
     Testing the ValueVector class
     """
+
     def test_single_value(self):
         """
         Creation of an object with three dimensions and unit.
         """
-        value = base.ValueVector(1, 2, 3, 'm')
+        value = base.ValueVector(1, 2, 3, "m")
         assert value.x == 1
         assert value.y == 2
         assert value.z == 3
-        assert value.unit == 'm'
+        assert value.unit == "m"
 
     def test_list(self):
         """
         Creation of an object with three dimensions of lists and unit.
         """
-        value = base.ValueVector([1, 2], [2, 3], [3, 4], 'm')
+        value = base.ValueVector([1, 2], [2, 3], [3, 4], "m")
         assert_equal(value.x, [1, 2])
         assert_equal(value.y, [2, 3])
         assert_equal(value.z, [3, 4])
-        assert value.unit == 'm'
+        assert value.unit == "m"
 
     def test_bad_unit(self):
         """
         Rejection of non-ASCII unit.
         """
         with self.assertRaises(ValueError):
-            _ = base.ValueVector(1, 2, 3, 'Å')
+            _ = base.ValueVector(1, 2, 3, "Å")
 
     def test_to_yaml(self):
         """
         Transform to yaml.
         """
-        value = base.ValueVector(1., 2., 3., 'm')
-        assert value.to_yaml() == 'x: 1.0\ny: 2.0\nz: 3.0\nunit: m\n'
+        value = base.ValueVector(1.0, 2.0, 3.0, "m")
+        assert value.to_yaml() == "x: 1.0\ny: 2.0\nz: 3.0\nunit: m\n"
 
     def test_two_dimensional_to_yaml(self):
         """
         Transform to yaml with only two dimensions.
         """
-        value = base.ValueVector(1., 2., None, 'm')
-        assert value.to_yaml() == 'x: 1.0\ny: 2.0\nz: null\nunit: m\n'
+        value = base.ValueVector(1.0, 2.0, None, "m")
+        assert value.to_yaml() == "x: 1.0\ny: 2.0\nz: null\nunit: m\n"
 
 
 class TestValueRange(unittest.TestCase):
     """
     Testing the ValueRange class
     """
+
     def test_single_value(self):
         """
         Creation of an object with a max, min and unit.
         """
-        value = base.ValueRange(1., 2., 'm')
+        value = base.ValueRange(1.0, 2.0, "m")
         assert value.min == 1
         assert value.max == 2
-        assert value.unit == 'm'
+        assert value.unit == "m"
 
     def test_list(self):
         """
         Creation of an object of a list of max and list of min and a unit.
         """
-        value = base.ValueRange([1, 2, 3], [2, 3, 4], 'm')
+        value = base.ValueRange([1, 2, 3], [2, 3, 4], "m")
         assert_equal(value.min, [1, 2, 3])
         assert_equal(value.max, [2, 3, 4])
-        assert value.unit == 'm'
+        assert value.unit == "m"
 
     def test_bad_unit(self):
         """
         Rejection of non-ASCII unit.
         """
         with self.assertRaises(ValueError):
-            _ = base.ValueRange(1., 2., 'Å')
+            _ = base.ValueRange(1.0, 2.0, "Å")
 
     def test_to_yaml(self):
         """
         Transform to yaml.
         """
-        value = base.ValueRange(1., 2., 'm')
-        assert value.to_yaml() == 'min: 1.0\nmax: 2.0\nunit: m\n'
+        value = base.ValueRange(1.0, 2.0, "m")
+        assert value.to_yaml() == "min: 1.0\nmax: 2.0\nunit: m\n"
 
     def test_no_upper_to_yaml(self):
         """
         Transform to yaml with no max.
         """
-        value = base.ValueRange(1., None)
-        assert value.to_yaml() == 'min: 1.0\nmax: null\n'
+        value = base.ValueRange(1.0, None)
+        assert value.to_yaml() == "min: 1.0\nmax: null\n"
 
     def test_no_lower_to_yaml(self):
         """
         Transform to yaml with no min.
         """
-        value = base.ValueRange(None, 1.)
-        assert value.to_yaml() == 'min: null\nmax: 1.0\n'
+        value = base.ValueRange(None, 1.0)
+        assert value.to_yaml() == "min: null\nmax: 1.0\n"
 
 
 class TestPerson(unittest.TestCase):
     """
     Testing the Person class
     """
+
     def test_creation(self):
         """
         Creation with no email.
         """
-        value = base.Person('Joe A. User', 'Ivy League University')
-        assert value.name == 'Joe A. User'
-        assert value.affiliation == 'Ivy League University'
+        value = base.Person("Joe A. User", "Ivy League University")
+        assert value.name == "Joe A. User"
+        assert value.affiliation == "Ivy League University"
 
     def test_creation_with_contact(self):
         """
         Creation with an email.
         """
-        value = base.Person('Joe A. User', 'Ivy League University',
-                            'jauser@ivy.edu')
-        assert value.name == 'Joe A. User'
-        assert value.affiliation == 'Ivy League University'
-        assert value.contact == 'jauser@ivy.edu'
+        value = base.Person("Joe A. User", "Ivy League University", "jauser@ivy.edu")
+        assert value.name == "Joe A. User"
+        assert value.affiliation == "Ivy League University"
+        assert value.contact == "jauser@ivy.edu"
 
     def test_to_yaml(self):
         """
         Transform to yaml with no email.
         """
-        value = base.Person('Joe A. User', 'Ivy League University')
-        assert value.to_yaml(
-        ) == 'name: Joe A. User\naffiliation: Ivy League University\n'
+        value = base.Person("Joe A. User", "Ivy League University")
+        assert value.to_yaml() == "name: Joe A. User\naffiliation: Ivy League University\n"
 
     def test_no_affiliation_to_yaml(self):
         """
         Transform to yaml without affiliation.
         """
-        value = base.Person('Joe A. User', None)
-        assert value.to_yaml() == 'name: Joe A. User\naffiliation: null\n'
+        value = base.Person("Joe A. User", None)
+        assert value.to_yaml() == "name: Joe A. User\naffiliation: null\n"
 
     def test_no_name_to_yaml(self):
         """
         Transform to yaml without name.
         """
-        value = base.Person(None, 'A University')
-        assert value.to_yaml() == 'name: null\naffiliation: A University\n'
+        value = base.Person(None, "A University")
+        assert value.to_yaml() == "name: null\naffiliation: A University\n"
 
     def test_email_to_yaml(self):
         """
         Transform to yaml with an email.
         """
-        value = base.Person('Joe A. User', 'Ivy League University',
-                            'jauser@ivy.edu')
-        assert value.to_yaml(
-        ) == 'name: Joe A. User\naffiliation: Ivy League University'\
-            + '\ncontact: jauser@ivy.edu\n'
+        value = base.Person("Joe A. User", "Ivy League University", "jauser@ivy.edu")
+        assert (
+            value.to_yaml() == "name: Joe A. User\naffiliation: Ivy League University" + "\ncontact: jauser@ivy.edu\n"
+        )
 
 
 class TestColumn(unittest.TestCase):
     """
     Testing the Column class
     """
+
     def test_creation(self):
         """
         Creation of a column.
         """
-        value = base.Column('q', '1/angstrom', 'qz vector')
-        assert value.dimension == 'qz vector'
-        assert value.name == 'q'
-        assert value.unit == '1/angstrom'
+        value = base.Column("q", "1/angstrom", "qz vector")
+        assert value.dimension == "qz vector"
+        assert value.name == "q"
+        assert value.unit == "1/angstrom"
 
     def test_bad_unit(self):
         """
         Rejection of non-ASCII unit.
         """
         with self.assertRaises(ValueError):
-            _ = base.Column('q', 'Å', 'qz vector')
+            _ = base.Column("q", "Å", "qz vector")
 
     def test_to_yaml(self):
         """
         Transformation to yaml.
         """
-        value = base.Column('q', '1/angstrom', 'qz vector')
-        assert value.to_yaml(
-        ) == 'name: q\nunit: 1/angstrom\ndimension: qz vector\n'
+        value = base.Column("q", "1/angstrom", "qz vector")
+        assert value.to_yaml() == "name: q\nunit: 1/angstrom\ndimension: qz vector\n"
 
     def test_no_description_to_yaml(self):
         """
         Transformation to yaml.
         """
-        value = base.Column('q', '1/angstrom')
-        assert value.to_yaml() == 'name: q\nunit: 1/angstrom\n'
+        value = base.Column("q", "1/angstrom")
+        assert value.to_yaml() == "name: q\nunit: 1/angstrom\n"
 
 
 class TestFile(unittest.TestCase):
     """
     Testing the File class.
     """
+
     def test_creation_for_nonexistent_file(self):
         """
         Creation of a file that does not exist.
         """
-        value = base.File('not_a_file.txt',
-                          datetime(2021, 7, 12, 14, 4, 20))
-        assert value.file == 'not_a_file.txt'
+        value = base.File("not_a_file.txt", datetime(2021, 7, 12, 14, 4, 20))
+        assert value.file == "not_a_file.txt"
         assert value.timestamp == datetime(2021, 7, 12, 14, 4, 20)
 
     def test_to_yaml_for_nonexistent_file(self):
         """
         Transformation to yaml of a file that does not exist.
         """
-        value = base.File('not_a_file.txt',
-                          datetime(2021, 7, 12, 14, 4, 20))
-        assert value.to_yaml() == 'file: not_a_file.txt\ntimestamp: '\
-            + '2021-07-12T14:04:20\n'
+        value = base.File("not_a_file.txt", datetime(2021, 7, 12, 14, 4, 20))
+        assert value.to_yaml() == "file: not_a_file.txt\ntimestamp: " + "2021-07-12T14:04:20\n"
 
     def test_creation_for_existing_file(self):
         """
         Creation for a file that does exist with a given modified date.
         """
-        fname = pathlib.Path('README.rst')
-        value = base.File(str(fname.absolute()),
-                          datetime.fromtimestamp(fname.stat().st_mtime))
-        assert value.file == str(
-            pathlib.Path().resolve().joinpath('README.rst'))
+        fname = pathlib.Path("README.rst")
+        value = base.File(str(fname.absolute()), datetime.fromtimestamp(fname.stat().st_mtime))
+        assert value.file == str(pathlib.Path().resolve().joinpath("README.rst"))
         assert value.timestamp == datetime.fromtimestamp(fname.stat().st_mtime)
 
     def test_to_yaml_for_existing_file(self):
@@ -281,23 +278,23 @@ class TestFile(unittest.TestCase):
         Transformation to yaml a file that does exist with a given modified
         date.
         """
-        fname = pathlib.Path('README.rst')
-        value = base.File(str(fname.absolute()),
-                          datetime.fromtimestamp(fname.stat().st_mtime))
-        assert value.to_yaml(
-        ) == f'file: {str(pathlib.Path().resolve().joinpath("README.rst"))}\n'\
-            + 'timestamp: '\
-            + f'{datetime.fromtimestamp(fname.stat().st_mtime).isoformat()}\n'
+        fname = pathlib.Path("README.rst")
+        value = base.File(str(fname.absolute()), datetime.fromtimestamp(fname.stat().st_mtime))
+        assert (
+            value.to_yaml()
+            == f'file: {str(pathlib.Path().resolve().joinpath("README.rst"))}\n'
+            + "timestamp: "
+            + f"{datetime.fromtimestamp(fname.stat().st_mtime).isoformat()}\n"
+        )
 
     def test_creation_for_existing_file_no_mod_time(self):
         """
             Transformation to yaml a file that does exist without a given
             modified date.
             """
-        fname = pathlib.Path('AUTHORS.rst')
+        fname = pathlib.Path("AUTHORS.rst")
         value = base.File(str(fname.absolute()), None)
-        assert value.file == str(
-            pathlib.Path().resolve().joinpath("AUTHORS.rst"))
+        assert value.file == str(pathlib.Path().resolve().joinpath("AUTHORS.rst"))
         assert value.timestamp == datetime.fromtimestamp(fname.stat().st_mtime)
 
     def test_to_yaml_for_existing_file_no_mod_time(self):
@@ -305,10 +302,12 @@ class TestFile(unittest.TestCase):
             Transformation to yaml a file that does exist without a given
             modified date.
             """
-        fname = pathlib.Path('AUTHORS.rst')
+        fname = pathlib.Path("AUTHORS.rst")
         value = base.File(str(fname.absolute()), None)
-        assert value.to_yaml(
-        ) == 'file: '\
-            + f'{str(pathlib.Path().resolve().joinpath("AUTHORS.rst"))}\n'\
-            + 'timestamp: '\
-            + f'{datetime.fromtimestamp(fname.stat().st_mtime).isoformat()}\n'
+        assert (
+            value.to_yaml()
+            == "file: "
+            + f'{str(pathlib.Path().resolve().joinpath("AUTHORS.rst"))}\n'
+            + "timestamp: "
+            + f"{datetime.fromtimestamp(fname.stat().st_mtime).isoformat()}\n"
+        )

--- a/tests/test_fileio/test_data_source.py
+++ b/tests/test_fileio/test_data_source.py
@@ -2,29 +2,30 @@
 Tests for fileio.data_source module
 """
 
-# author: Andrew R. McCluskey (arm61)
-
-import unittest
 import pathlib
+import unittest
+
 from datetime import datetime
-from orsopy.fileio import data_source, base
+
+from orsopy.fileio import base, data_source
 
 
 class TestExperiment(unittest.TestCase):
     """
     Testing the Experiment class.
     """
+
     def test_creation(self):
         """
         Creation with minimal set.
         """
-        value = data_source.Experiment('My First Experiment',
-                                       'A Lab Instrument',
-                                       datetime(1992, 7, 14).strftime("%Y-%m-%d"), 'x-rays')
+        value = data_source.Experiment(
+            "My First Experiment", "A Lab Instrument", datetime(1992, 7, 14).strftime("%Y-%m-%d"), "x-rays"
+        )
         assert value.title == "My First Experiment"
-        assert value.instrument == 'A Lab Instrument'
-        assert value.start_date == '1992-07-14'
-        assert value.probe == 'x-rays'
+        assert value.instrument == "A Lab Instrument"
+        assert value.start_date == "1992-07-14"
+        assert value.probe == "x-rays"
         assert value.facility is None
         assert value.proposalID is None
         assert value.doi is None
@@ -33,48 +34,55 @@ class TestExperiment(unittest.TestCase):
         """
         Transformation to yaml with minimal set.
         """
-        value = data_source.Experiment('My First Experiment',
-                                       'A Lab Instrument',
-                                       datetime(1992, 7, 14).strftime("%Y-%m-%d"), 'x-rays')
-        assert value.to_yaml() == 'title: My First Experiment\n'\
-            + 'instrument: A Lab Instrument\nstart_date: \'1992-07-14\''\
-            + '\nprobe: x-rays\n'
+        value = data_source.Experiment(
+            "My First Experiment", "A Lab Instrument", datetime(1992, 7, 14).strftime("%Y-%m-%d"), "x-rays"
+        )
+        assert (
+            value.to_yaml()
+            == "title: My First Experiment\n"
+            + "instrument: A Lab Instrument\nstart_date: '1992-07-14'"
+            + "\nprobe: x-rays\n"
+        )
 
     def test_creation_optionals(self):
         """
         Creation with optionals.
         """
-        value = data_source.Experiment('My First Neutron Experiment',
-                                       'TAS8',
-                                       datetime(1992, 7, 14).strftime("%Y-%m-%d"),
-                                       'neutrons',
-                                       facility='Risoe',
-                                       proposalID='abc123',
-                                       doi='10.0000/abc1234')
+        value = data_source.Experiment(
+            "My First Neutron Experiment",
+            "TAS8",
+            datetime(1992, 7, 14).strftime("%Y-%m-%d"),
+            "neutrons",
+            facility="Risoe",
+            proposalID="abc123",
+            doi="10.0000/abc1234",
+        )
         assert value.title == "My First Neutron Experiment"
-        assert value.instrument == 'TAS8'
-        assert value.start_date == '1992-07-14'
-        assert value.probe == 'neutrons'
-        assert value.facility == 'Risoe'
-        assert value.proposalID == 'abc123'
-        assert value.doi == '10.0000/abc1234'
+        assert value.instrument == "TAS8"
+        assert value.start_date == "1992-07-14"
+        assert value.probe == "neutrons"
+        assert value.facility == "Risoe"
+        assert value.proposalID == "abc123"
+        assert value.doi == "10.0000/abc1234"
 
     def test_to_yaml_optionals(self):
         """
         Transformation to yaml with optionals.
         """
-        value = data_source.Experiment('My First Neutron Experiment',
-                                       'TAS8',
-                                       datetime(1992, 7, 14).strftime("%Y-%m-%d"),
-                                       'neutrons',
-                                       facility='Risoe',
-                                       proposalID='abc123',
-                                       doi='10.0000/abc1234')
+        value = data_source.Experiment(
+            "My First Neutron Experiment",
+            "TAS8",
+            datetime(1992, 7, 14).strftime("%Y-%m-%d"),
+            "neutrons",
+            facility="Risoe",
+            proposalID="abc123",
+            doi="10.0000/abc1234",
+        )
         assert value.to_yaml() == (
-            'title: My First Neutron Experiment\n'
-            'instrument: TAS8\nstart_date: \'1992-07-14\''
-            '\nprobe: neutrons\nfacility: Risoe\nproposalID: '
-            'abc123\ndoi: 10.0000/abc1234\n'
+            "title: My First Neutron Experiment\n"
+            "instrument: TAS8\nstart_date: '1992-07-14'"
+            "\nprobe: neutrons\nfacility: Risoe\nproposalID: "
+            "abc123\ndoi: 10.0000/abc1234\n"
         )
 
 
@@ -82,12 +90,13 @@ class TestSample(unittest.TestCase):
     """
     Testing for the Sample class.
     """
+
     def test_creation(self):
         """
         Creation with a minimal set.
         """
-        value = data_source.Sample('A Perfect Sample')
-        assert value.name == 'A Perfect Sample'
+        value = data_source.Sample("A Perfect Sample")
+        assert value.name == "A Perfect Sample"
         assert value.category is None
         assert value.composition is None
         assert value.description is None
@@ -97,241 +106,224 @@ class TestSample(unittest.TestCase):
         """
         Transformation to yaml with a minimal set.
         """
-        value = data_source.Sample('A Perfect Sample')
-        assert value.to_yaml() == 'name: A Perfect Sample\n'
+        value = data_source.Sample("A Perfect Sample")
+        assert value.to_yaml() == "name: A Perfect Sample\n"
 
     def test_creation_optionals(self):
         """
         Creation with a optionals.
         """
         value = data_source.Sample(
-            'A Perfect Sample',
-            category='solid/gas',
-            composition='Si | SiO2(20 A) | Fe(200 A) | air(beam side)',
-            description='The sample is without flaws',
-            environment='Temperature cell')
-        assert value.name == 'A Perfect Sample'
-        assert value.category == 'solid/gas'
-        assert value.composition == 'Si | SiO2(20 A) | '\
-            + 'Fe(200 A) | air(beam side)'
-        assert value.description == 'The sample is without flaws'
-        assert value.environment == 'Temperature cell'
+            "A Perfect Sample",
+            category="solid/gas",
+            composition="Si | SiO2(20 A) | Fe(200 A) | air(beam side)",
+            description="The sample is without flaws",
+            environment="Temperature cell",
+        )
+        assert value.name == "A Perfect Sample"
+        assert value.category == "solid/gas"
+        assert value.composition == "Si | SiO2(20 A) | " + "Fe(200 A) | air(beam side)"
+        assert value.description == "The sample is without flaws"
+        assert value.environment == "Temperature cell"
 
     def test_to_yaml_optionals(self):
         """
         Transformation to yaml with optionals.
         """
         value = data_source.Sample(
-            'A Perfect Sample',
-            category='solid/gas',
-            composition='Si | SiO2(20 A) | Fe(200 A) | air(beam side)',
-            description='The sample is without flaws',
-            environment='Temperature cell')
-        assert value.to_yaml() == 'name: A Perfect Sample\ncategory: '\
-            + 'solid/gas\ncomposition: Si | SiO2(20 A) | Fe(200 A) | air'\
-            + '(beam side)\ndescription: The sample is without flaws\n'\
-            + 'environment: Temperature cell\n'
+            "A Perfect Sample",
+            category="solid/gas",
+            composition="Si | SiO2(20 A) | Fe(200 A) | air(beam side)",
+            description="The sample is without flaws",
+            environment="Temperature cell",
+        )
+        assert (
+            value.to_yaml()
+            == "name: A Perfect Sample\ncategory: "
+            + "solid/gas\ncomposition: Si | SiO2(20 A) | Fe(200 A) | air"
+            + "(beam side)\ndescription: The sample is without flaws\n"
+            + "environment: Temperature cell\n"
+        )
 
 
 class TestDataSource(unittest.TestCase):
     """
     Tests for the DataSource class.
     """
+
     def test_creation(self):
         """
         Creation with only default.
         """
-        inst = data_source.InstrumentSettings(
-            base.Value(0.25, unit='deg'),
-            base.ValueRange(2, 20, unit="angstrom")
-        )
-        df = [
-            base.File("1.nx.hdf", datetime.now()),
-            base.File("2.nx.hdf", datetime.now())
-        ]
+        inst = data_source.InstrumentSettings(base.Value(0.25, unit="deg"), base.ValueRange(2, 20, unit="angstrom"))
+        df = [base.File("1.nx.hdf", datetime.now()), base.File("2.nx.hdf", datetime.now())]
         m = data_source.Measurement(inst, df, scheme="angle-dispersive")
 
         value = data_source.DataSource(
-            base.Person('A Person', 'Some Uni'),
-            data_source.Experiment('My First Experiment', 'A Lab Instrument',
-                                   datetime(1992, 7, 14).strftime("%Y-%m-%d"), 'x-rays'),
-            data_source.Sample('A Perfect Sample'),
-            m)
-        assert value.owner.name == 'A Person'
-        assert value.owner.affiliation == 'Some Uni'
-        assert value.experiment.title == 'My First Experiment'
-        assert value.experiment.instrument == 'A Lab Instrument'
-        assert value.experiment.start_date == '1992-07-14'
-        assert value.experiment.probe == 'x-rays'
-        assert value.sample.name == 'A Perfect Sample'
+            base.Person("A Person", "Some Uni"),
+            data_source.Experiment(
+                "My First Experiment", "A Lab Instrument", datetime(1992, 7, 14).strftime("%Y-%m-%d"), "x-rays"
+            ),
+            data_source.Sample("A Perfect Sample"),
+            m,
+        )
+        assert value.owner.name == "A Person"
+        assert value.owner.affiliation == "Some Uni"
+        assert value.experiment.title == "My First Experiment"
+        assert value.experiment.instrument == "A Lab Instrument"
+        assert value.experiment.start_date == "1992-07-14"
+        assert value.experiment.probe == "x-rays"
+        assert value.sample.name == "A Perfect Sample"
 
 
 class TestInstrumentSettings(unittest.TestCase):
     """
     Tests for the InstrumentSettings class.
     """
+
     def test_creation(self):
         """
         Creation with minimal settings.
         """
-        value = data_source.InstrumentSettings(
-            base.Value(4., 'deg'),
-            base.ValueRange(2., 12., 'angstrom'),
-        )
-        assert value.incident_angle.magnitude == 4.
-        assert value.incident_angle.unit == 'deg'
-        assert value.wavelength.min == 2.
-        assert value.wavelength.max == 12.
-        assert value.wavelength.unit == 'angstrom'
-        assert value.polarization == 'unpolarized'
+        value = data_source.InstrumentSettings(base.Value(4.0, "deg"), base.ValueRange(2.0, 12.0, "angstrom"),)
+        assert value.incident_angle.magnitude == 4.0
+        assert value.incident_angle.unit == "deg"
+        assert value.wavelength.min == 2.0
+        assert value.wavelength.max == 12.0
+        assert value.wavelength.unit == "angstrom"
+        assert value.polarization == "unpolarized"
         assert value.configuration is None
 
     def test_to_yaml(self):
         """
         Transformation to yaml with minimal set.
         """
-        value = data_source.InstrumentSettings(
-            base.Value(4., 'deg'),
-            base.ValueRange(2., 12., 'angstrom'),
+        value = data_source.InstrumentSettings(base.Value(4.0, "deg"), base.ValueRange(2.0, 12.0, "angstrom"),)
+        assert (
+            value.to_yaml()
+            == "incident_angle:\n  magnitude: "
+            + "4.0\n  unit: deg\nwavelength:\n  min: 2.0\n  "
+            + "max: 12.0\n  unit: angstrom\npolarization: unpolarized\n"
         )
-        assert value.to_yaml() == 'incident_angle:\n  magnitude: '\
-            + '4.0\n  unit: deg\nwavelength:\n  min: 2.0\n  '\
-            + 'max: 12.0\n  unit: angstrom\npolarization: unpolarized\n'
 
     def test_creation_config_and_polarization(self):
         """
         Creation with optional items.
         """
-        value = data_source.InstrumentSettings(base.Value(4., 'deg'),
-                                               base.ValueRange(
-                                                   2., 12., 'angstrom'),
-                                               polarization='p',
-                                               configuration='liquid surface')
-        assert value.incident_angle.magnitude == 4.
-        assert value.incident_angle.unit == 'deg'
-        assert value.wavelength.min == 2.
-        assert value.wavelength.max == 12.
-        assert value.wavelength.unit == 'angstrom'
-        assert value.polarization == 'p'
-        assert value.configuration == 'liquid surface'
+        value = data_source.InstrumentSettings(
+            base.Value(4.0, "deg"),
+            base.ValueRange(2.0, 12.0, "angstrom"),
+            polarization="p",
+            configuration="liquid surface",
+        )
+        assert value.incident_angle.magnitude == 4.0
+        assert value.incident_angle.unit == "deg"
+        assert value.wavelength.min == 2.0
+        assert value.wavelength.max == 12.0
+        assert value.wavelength.unit == "angstrom"
+        assert value.polarization == "p"
+        assert value.configuration == "liquid surface"
 
     def test_to_yaml_config_and_polarization(self):
         """
         Transformation to yaml with optional items.
         """
-        value = data_source.InstrumentSettings(base.Value(4., 'deg'),
-                                               base.ValueRange(
-                                                   2., 12., 'angstrom'),
-                                               polarization='p',
-                                               configuration='liquid surface')
-        assert value.to_yaml() == 'incident_angle:\n  magnitude: '\
-            + '4.0\n  unit: deg\nwavelength:\n  min: 2.0\n  '\
-            + 'max: 12.0\n  unit: angstrom\npolarization: p\n'\
-            + 'configuration: liquid surface\n'
+        value = data_source.InstrumentSettings(
+            base.Value(4.0, "deg"),
+            base.ValueRange(2.0, 12.0, "angstrom"),
+            polarization="p",
+            configuration="liquid surface",
+        )
+        assert (
+            value.to_yaml()
+            == "incident_angle:\n  magnitude: "
+            + "4.0\n  unit: deg\nwavelength:\n  min: 2.0\n  "
+            + "max: 12.0\n  unit: angstrom\npolarization: p\n"
+            + "configuration: liquid surface\n"
+        )
 
 
 class TestMeasurement(unittest.TestCase):
     """
     Tests for the Measurement class.
     """
+
     def test_creation(self):
         """
         Creation with minimal set.
         """
         value = data_source.Measurement(
-            data_source.InstrumentSettings(
-                base.Value(4., 'deg'),
-                base.ValueRange(2., 12., 'angstrom'),
-            ), [
-                base.File(str(pathlib.Path().resolve().joinpath("README.rst")),
-                          None)
-            ])
+            data_source.InstrumentSettings(base.Value(4.0, "deg"), base.ValueRange(2.0, 12.0, "angstrom"),),
+            [base.File(str(pathlib.Path().resolve().joinpath("README.rst")), None)],
+        )
         assert value.instrument_settings.incident_angle.magnitude == 4.0
-        assert value.instrument_settings.incident_angle.unit == 'deg'
+        assert value.instrument_settings.incident_angle.unit == "deg"
         assert value.instrument_settings.wavelength.min == 2.0
         assert value.instrument_settings.wavelength.max == 12.0
-        assert value.instrument_settings.wavelength.unit == 'angstrom'
-        assert value.data_files[0].file == str(
-            pathlib.Path().resolve().joinpath("README.rst"))
-        assert value.data_files[0].timestamp == datetime.fromtimestamp(
-            pathlib.Path('README.rst').stat().st_mtime)
+        assert value.instrument_settings.wavelength.unit == "angstrom"
+        assert value.data_files[0].file == str(pathlib.Path().resolve().joinpath("README.rst"))
+        assert value.data_files[0].timestamp == datetime.fromtimestamp(pathlib.Path("README.rst").stat().st_mtime)
 
     def test_to_yaml(self):
         """
         Transform to yaml with minimal set.
         """
         value = data_source.Measurement(
-            data_source.InstrumentSettings(
-                base.Value(4., 'deg'),
-                base.ValueRange(2., 12., 'angstrom'),
-            ), [
-                base.File(str(pathlib.Path().resolve().joinpath("README.rst")),
-                          None)
-            ])
-        fname = pathlib.Path('README.rst')
-        assert value.to_yaml() == 'instrument_settings:\n  incident_angle:'\
-            + '\n    magnitude: 4.0\n    unit: deg\n  wavelength:\n    min: '\
-            + '2.0\n    max: 12.0\n    unit: angstrom\n  polarization: '\
-            + 'unpolarized\ndata_files:\n- file: '\
-            + f'{str(fname.absolute())}\n  timestamp: '\
-            + f'{datetime.fromtimestamp(fname.stat().st_mtime).isoformat()}\n'
+            data_source.InstrumentSettings(base.Value(4.0, "deg"), base.ValueRange(2.0, 12.0, "angstrom"),),
+            [base.File(str(pathlib.Path().resolve().joinpath("README.rst")), None)],
+        )
+        fname = pathlib.Path("README.rst")
+        assert (
+            value.to_yaml()
+            == "instrument_settings:\n  incident_angle:"
+            + "\n    magnitude: 4.0\n    unit: deg\n  wavelength:\n    min: "
+            + "2.0\n    max: 12.0\n    unit: angstrom\n  polarization: "
+            + "unpolarized\ndata_files:\n- file: "
+            + f"{str(fname.absolute())}\n  timestamp: "
+            + f"{datetime.fromtimestamp(fname.stat().st_mtime).isoformat()}\n"
+        )
 
     def test_creation_optionals(self):
         """
         Creation with optionals.
         """
         value = data_source.Measurement(
-            data_source.InstrumentSettings(
-                base.Value(4., 'deg'),
-                base.ValueRange(2., 12., 'angstrom'),
-            ), [
-                base.File(str(pathlib.Path().resolve().joinpath("README.rst")),
-                          None)
-            ], [
-                base.File(
-                    str(pathlib.Path().resolve().joinpath("AUTHORS.rst")),
-                    None)
-            ])
+            data_source.InstrumentSettings(base.Value(4.0, "deg"), base.ValueRange(2.0, 12.0, "angstrom"),),
+            [base.File(str(pathlib.Path().resolve().joinpath("README.rst")), None)],
+            [base.File(str(pathlib.Path().resolve().joinpath("AUTHORS.rst")), None)],
+        )
         assert value.instrument_settings.incident_angle.magnitude == 4.0
-        assert value.instrument_settings.incident_angle.unit == 'deg'
+        assert value.instrument_settings.incident_angle.unit == "deg"
         assert value.instrument_settings.wavelength.min == 2.0
         assert value.instrument_settings.wavelength.max == 12.0
-        assert value.instrument_settings.wavelength.unit == 'angstrom'
-        assert value.data_files[0].file == str(
-            pathlib.Path().resolve().joinpath("README.rst"))
-        assert value.data_files[0].timestamp == datetime.fromtimestamp(
-            pathlib.Path('README.rst').stat().st_mtime)
-        assert value.references[0].file == str(
-            pathlib.Path().resolve().joinpath("AUTHORS.rst"))
-        assert value.references[
-            0].timestamp == datetime.fromtimestamp(
-                pathlib.Path('AUTHORS.rst').stat().st_mtime)
+        assert value.instrument_settings.wavelength.unit == "angstrom"
+        assert value.data_files[0].file == str(pathlib.Path().resolve().joinpath("README.rst"))
+        assert value.data_files[0].timestamp == datetime.fromtimestamp(pathlib.Path("README.rst").stat().st_mtime)
+        assert value.references[0].file == str(pathlib.Path().resolve().joinpath("AUTHORS.rst"))
+        assert value.references[0].timestamp == datetime.fromtimestamp(pathlib.Path("AUTHORS.rst").stat().st_mtime)
 
     def test_to_yaml_optionals(self):
         """
         Transform to yaml with optionals.
         """
         value = data_source.Measurement(
-            data_source.InstrumentSettings(
-                base.Value(4., 'deg'),
-                base.ValueRange(2., 12., 'angstrom'),
-            ), [
-                base.File(str(pathlib.Path().resolve().joinpath("README.rst")),
-                          None)
-            ], [
-                base.File(
-                    str(pathlib.Path().resolve().joinpath("AUTHORS.rst")),
-                    None)
-            ], 'energy-dispersive')
-        fname = pathlib.Path('README.rst')
-        gname = pathlib.Path('AUTHORS.rst')
-        assert value.to_yaml() == 'instrument_settings:\n  incident_angle:'\
-            + '\n    magnitude: 4.0\n    unit: deg\n  wavelength:\n    min: '\
-            + '2.0\n    max: 12.0\n    unit: angstrom\n  polarization: '\
-            + 'unpolarized\ndata_files:\n- file: '\
-            + f'{str(fname.absolute())}\n  timestamp: '\
-            + f'{datetime.fromtimestamp(fname.stat().st_mtime).isoformat()}\n'\
-            + 'references:\n- file: '\
-            + f'{str(gname.absolute())}\n  timestamp: '\
-            + f'{datetime.fromtimestamp(gname.stat().st_mtime).isoformat()}\n'\
-            + 'scheme: energy-dispersive\n'
+            data_source.InstrumentSettings(base.Value(4.0, "deg"), base.ValueRange(2.0, 12.0, "angstrom"),),
+            [base.File(str(pathlib.Path().resolve().joinpath("README.rst")), None)],
+            [base.File(str(pathlib.Path().resolve().joinpath("AUTHORS.rst")), None)],
+            "energy-dispersive",
+        )
+        fname = pathlib.Path("README.rst")
+        gname = pathlib.Path("AUTHORS.rst")
+        assert (
+            value.to_yaml()
+            == "instrument_settings:\n  incident_angle:"
+            + "\n    magnitude: 4.0\n    unit: deg\n  wavelength:\n    min: "
+            + "2.0\n    max: 12.0\n    unit: angstrom\n  polarization: "
+            + "unpolarized\ndata_files:\n- file: "
+            + f"{str(fname.absolute())}\n  timestamp: "
+            + f"{datetime.fromtimestamp(fname.stat().st_mtime).isoformat()}\n"
+            + "references:\n- file: "
+            + f"{str(gname.absolute())}\n  timestamp: "
+            + f"{datetime.fromtimestamp(gname.stat().st_mtime).isoformat()}\n"
+            + "scheme: energy-dispersive\n"
+        )

--- a/tests/test_fileio/test_reduction.py
+++ b/tests/test_fileio/test_reduction.py
@@ -2,142 +2,154 @@
 Tests for fileio.reduction module
 """
 
-# author: Andrew R. McCluskey (arm61)
-
-import unittest
 import datetime
-from orsopy.fileio import reduction, base
+import unittest
+
+from orsopy.fileio import base, reduction
 
 
 class TestSoftware(unittest.TestCase):
     """
     Tests for the Software class.
     """
+
     def test_creation(self):
         """
         Creation of object with all arguments.
         """
-        value = reduction.Software('Reducer', '1.2.3', 'Ubuntu-20.04')
-        assert value.name == 'Reducer'
-        assert value.version == '1.2.3'
-        assert value.platform == 'Ubuntu-20.04'
+        value = reduction.Software("Reducer", "1.2.3", "Ubuntu-20.04")
+        assert value.name == "Reducer"
+        assert value.version == "1.2.3"
+        assert value.platform == "Ubuntu-20.04"
 
     def test_to_yaml(self):
         """
         Transform to yaml.
         """
-        value = reduction.Software('Reducer', '1.2.3', 'Ubuntu-20.04')
-        assert value.to_yaml(
-        ) == 'name: Reducer\nversion: 1.2.3\nplatform: Ubuntu-20.04\n'
+        value = reduction.Software("Reducer", "1.2.3", "Ubuntu-20.04")
+        assert value.to_yaml() == "name: Reducer\nversion: 1.2.3\nplatform: Ubuntu-20.04\n"
 
     def test_no_name_to_yaml(self):
         """
         Transform to yaml with no name.
         """
-        value = reduction.Software(None, '1.0.0', 'WindowsXP')
-        assert value.to_yaml(
-        ) == 'name: null\nversion: 1.0.0\nplatform: WindowsXP\n'
+        value = reduction.Software(None, "1.0.0", "WindowsXP")
+        assert value.to_yaml() == "name: null\nversion: 1.0.0\nplatform: WindowsXP\n"
 
 
 class TestReduction(unittest.TestCase):
     """
     Tests for the Reduction class.
     """
+
     def test_creation(self):
         """
         Creation of an reduction class with minimal options.
         """
         value = reduction.Reduction(
-            reduction.Software('Reducer', '1.2.3', 'Ubuntu-20.04'),
+            reduction.Software("Reducer", "1.2.3", "Ubuntu-20.04"),
             datetime.datetime(2021, 7, 7, 9, 11, 20),
-            base.Person('A Person', 'University'),
-            ['footprint doi', 'background'])
-        assert value.software == reduction.Software('Reducer', '1.2.3',
-                                                    'Ubuntu-20.04')
+            base.Person("A Person", "University"),
+            ["footprint doi", "background"],
+        )
+        assert value.software == reduction.Software("Reducer", "1.2.3", "Ubuntu-20.04")
         assert value.timestamp == datetime.datetime(2021, 7, 7, 9, 11, 20)
-        assert value.creator == base.Person('A Person', 'University')
-        assert value.corrections == ['footprint doi', 'background']
+        assert value.creator == base.Person("A Person", "University")
+        assert value.corrections == ["footprint doi", "background"]
 
     def test_to_yaml(self):
         """
         Transform minimal options to yaml.
         """
         value = reduction.Reduction(
-            reduction.Software('Reducer', '1.2.3', 'Ubuntu-20.04'),
+            reduction.Software("Reducer", "1.2.3", "Ubuntu-20.04"),
             datetime.datetime(2021, 7, 7, 9, 11, 20),
-            base.Person('A Person', 'University'),
-            ['footprint doi', 'background'])
-        assert value.to_yaml(
-        ) == 'software:\n  name: Reducer\n  version: 1.2.3\n  '\
-            + 'platform: Ubuntu-20.04\ntimestamp: 2021-07-07T09:11:20\n'\
-            + 'creator:\n  name: A Person\n  affiliation: University\n'\
-            + 'corrections:\n- footprint doi\n- background\n'
+            base.Person("A Person", "University"),
+            ["footprint doi", "background"],
+        )
+        assert (
+            value.to_yaml()
+            == "software:\n  name: Reducer\n  version: 1.2.3\n  "
+            + "platform: Ubuntu-20.04\ntimestamp: 2021-07-07T09:11:20\n"
+            + "creator:\n  name: A Person\n  affiliation: University\n"
+            + "corrections:\n- footprint doi\n- background\n"
+        )
 
     def test_call_to_yaml(self):
         """
         Tranform with call to yaml.
         """
-        value = reduction.Reduction(reduction.Software('Reducer', '1.2.3',
-                                                       'Ubuntu-20.04'),
-                                    datetime.datetime(2021, 7, 7, 9, 11, 20),
-                                    base.Person('A Person', 'University'),
-                                    ['footprint doi', 'background'],
-                                    call='sh myreducer.sh 1 0')
-        assert value.to_yaml(
-        ) == ('software:\n  name: Reducer\n  version: 1.2.3\n  '
-              'platform: Ubuntu-20.04\ntimestamp: 2021-07-07T09:11:20\n'
-              'creator:\n  name: A Person\n  affiliation: University\n'
-              'corrections:\n- footprint doi\n- background\ncall: '
-              'sh myreducer.sh 1 0\n'
-              )
+        value = reduction.Reduction(
+            reduction.Software("Reducer", "1.2.3", "Ubuntu-20.04"),
+            datetime.datetime(2021, 7, 7, 9, 11, 20),
+            base.Person("A Person", "University"),
+            ["footprint doi", "background"],
+            call="sh myreducer.sh 1 0",
+        )
+        assert value.to_yaml() == (
+            "software:\n  name: Reducer\n  version: 1.2.3\n  "
+            "platform: Ubuntu-20.04\ntimestamp: 2021-07-07T09:11:20\n"
+            "creator:\n  name: A Person\n  affiliation: University\n"
+            "corrections:\n- footprint doi\n- background\ncall: "
+            "sh myreducer.sh 1 0\n"
+        )
 
     def test_script_to_yaml(self):
         """
         Tranform with script to yaml.
         """
         value = reduction.Reduction(
-            reduction.Software('Reducer', '1.2.3', 'Ubuntu-20.04'),
+            reduction.Software("Reducer", "1.2.3", "Ubuntu-20.04"),
             datetime.datetime(2021, 7, 7, 9, 11, 20),
-            base.Person('A Person',
-                        'University'), ['footprint doi', 'background'],
-            script='/home/user/user1/scripts/reducer.py')
-        assert value.to_yaml(
-        ) == 'software:\n  name: Reducer\n  version: 1.2.3\n  '\
-            + 'platform: Ubuntu-20.04\ntimestamp: 2021-07-07T09:11:20\n'\
-            + 'creator:\n  name: A Person\n  affiliation: University\n'\
-            + 'corrections:\n- footprint doi\n- background\nscript: '\
-            + '/home/user/user1/scripts/reducer.py\n'
+            base.Person("A Person", "University"),
+            ["footprint doi", "background"],
+            script="/home/user/user1/scripts/reducer.py",
+        )
+        assert (
+            value.to_yaml()
+            == "software:\n  name: Reducer\n  version: 1.2.3\n  "
+            + "platform: Ubuntu-20.04\ntimestamp: 2021-07-07T09:11:20\n"
+            + "creator:\n  name: A Person\n  affiliation: University\n"
+            + "corrections:\n- footprint doi\n- background\nscript: "
+            + "/home/user/user1/scripts/reducer.py\n"
+        )
 
     def test_computer_to_yaml(self):
         """
         Tranform with computer to yaml.
         """
-        value = reduction.Reduction(reduction.Software('Reducer', '1.2.3',
-                                                       'Ubuntu-20.04'),
-                                    datetime.datetime(2021, 7, 7, 9, 11, 20),
-                                    base.Person('A Person', 'University'),
-                                    ['footprint doi', 'background'],
-                                    computer='cluster.esss.dk')
-        assert value.to_yaml(
-        ) == 'software:\n  name: Reducer\n  version: 1.2.3\n  '\
-            + 'platform: Ubuntu-20.04\ntimestamp: 2021-07-07T09:11:20\n'\
-            + 'creator:\n  name: A Person\n  affiliation: University\n'\
-            + 'corrections:\n- footprint doi\n- background\ncomputer: '\
-            + 'cluster.esss.dk\n'
+        value = reduction.Reduction(
+            reduction.Software("Reducer", "1.2.3", "Ubuntu-20.04"),
+            datetime.datetime(2021, 7, 7, 9, 11, 20),
+            base.Person("A Person", "University"),
+            ["footprint doi", "background"],
+            computer="cluster.esss.dk",
+        )
+        assert (
+            value.to_yaml()
+            == "software:\n  name: Reducer\n  version: 1.2.3\n  "
+            + "platform: Ubuntu-20.04\ntimestamp: 2021-07-07T09:11:20\n"
+            + "creator:\n  name: A Person\n  affiliation: University\n"
+            + "corrections:\n- footprint doi\n- background\ncomputer: "
+            + "cluster.esss.dk\n"
+        )
 
     def test_binary_to_yaml(self):
         """
         Tranform with computer to yaml.
         """
-        value = reduction.Reduction(reduction.Software('Reducer', '1.2.3',
-                                                       'Ubuntu-20.04'),
-                                    datetime.datetime(2021, 7, 7, 9, 11, 20),
-                                    base.Person('A Person', 'University'),
-                                    ['footprint doi', 'background'],
-                                    binary='/home/users/user1/bin/file')
-        assert value.to_yaml(
-        ) == 'software:\n  name: Reducer\n  version: 1.2.3\n  '\
-            + 'platform: Ubuntu-20.04\ntimestamp: 2021-07-07T09:11:20\n'\
-            + 'creator:\n  name: A Person\n  affiliation: University\n'\
-            + 'corrections:\n- footprint doi\n- background\nbinary: '\
-            + '/home/users/user1/bin/file\n'
+        value = reduction.Reduction(
+            reduction.Software("Reducer", "1.2.3", "Ubuntu-20.04"),
+            datetime.datetime(2021, 7, 7, 9, 11, 20),
+            base.Person("A Person", "University"),
+            ["footprint doi", "background"],
+            binary="/home/users/user1/bin/file",
+        )
+        assert (
+            value.to_yaml()
+            == "software:\n  name: Reducer\n  version: 1.2.3\n  "
+            + "platform: Ubuntu-20.04\ntimestamp: 2021-07-07T09:11:20\n"
+            + "creator:\n  name: A Person\n  affiliation: University\n"
+            + "corrections:\n- footprint doi\n- background\nbinary: "
+            + "/home/users/user1/bin/file\n"
+        )

--- a/tests/test_fileio/test_schema.py
+++ b/tests/test_fileio/test_schema.py
@@ -1,10 +1,12 @@
 import json
 import os.path
+
 import jsonschema
+import numpy as np
 import yaml
+
 from orsopy import fileio
 from orsopy.fileio.base import _read_header_data, _validate_header_data
-import numpy as np
 
 
 class TestSchema:
@@ -14,28 +16,20 @@ class TestSchema:
         with open(schema_pth, "r") as f:
             schema = json.load(f)
 
-        dct_list, data, version = _read_header_data(
-            os.path.join("tests", "test_example.ort"),
-            validate=True
-        )
+        dct_list, data, version = _read_header_data(os.path.join("tests", "test_example.ort"), validate=True)
         assert data[0].shape == (2, 4)
         assert version == "0.1"
 
         # d contains datetime.datetime objects, which would fail the
         # jsonschema validation, so force those to be strings.
-        modified_dct_list = [
-            json.loads(json.dumps(dct, default=str)) for dct in dct_list
-        ]
+        modified_dct_list = [json.loads(json.dumps(dct, default=str)) for dct in dct_list]
         for dct in modified_dct_list:
             jsonschema.validate(dct, schema)
 
         _validate_header_data(dct_list)
 
         # try a 2 dataset file
-        dct_list, data, version = _read_header_data(
-            os.path.join("tests", "test_example2.ort"),
-            validate=True
-        )
+        dct_list, data, version = _read_header_data(os.path.join("tests", "test_example2.ort"), validate=True)
         assert len(dct_list) == 2
         assert dct_list[1]["data_set"] == "spin_down"
         assert data[1].shape == (4, 4)

--- a/tests/test_orsopy.py
+++ b/tests/test_orsopy.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
-
 """Tests for `orsopy` package."""
 
 import pytest
-
 
 from orsopy import orsopy


### PR DESCRIPTION
As preparation to transfer slddb to orsopy I have looked into the usage of black and ran it on the project. In the same spirit I found that isort would also be a good addition for us to keep the import section tidy and equivalent for the whole package.

I have therefore added a description how to run this to the contributing section of the documentation. The code is also updated to what it would looks like after running these commands.

One additional thing I changed might need some discussion here. I removed the author comments that have been in several files for the following reasons:

1. Most files are touched by many of us, so they don't really have an Author in that sense.
2. We do have author information in a separate file now so that everyone get's the credit they deserve.
3. The git repository itself is a better indication of who contributed what to the project (and whom to ask about it, potentially)

Any comments are welcome. Black doesn't have any configuration parameters, so we will have to live with the look of the results, but for me the changes mostly looked reasonable.
