### PR TITLE
Fix order of str in Union to create objects properly

### DIFF
--- a/orsopy/dataclasses.py
+++ b/orsopy/dataclasses.py
@@ -1,6 +1,7 @@
 import sys
-from dataclasses import (dataclass, _FIELD, _FIELD_INITVAR, _FIELDS, _HAS_DEFAULT_FACTORY, _POST_INIT_NAME, MISSING,
-                         _create_fn, _field_init, _init_param, _set_new_attribute, field, fields)
+
+from dataclasses import (_FIELD, _FIELD_INITVAR, _FIELDS, _HAS_DEFAULT_FACTORY, _POST_INIT_NAME, MISSING, _create_fn,
+                         _field_init, _init_param, _set_new_attribute, dataclass, field, fields)
 
 # change of signature introduced in python 3.10.1
 if sys.version_info >= (3, 10, 1):

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -268,8 +268,11 @@ class Header:
                 continue
             elif isclass(fld.type) and issubclass(fld.type, Header):
                 attr_items[fld.name] = fld.type.empty()
-            elif get_origin(fld.type) is Union and isclass(get_args(fld.type)[0]) \
-                    and issubclass(get_args(fld.type)[0], Header):
+            elif (
+                get_origin(fld.type) is Union
+                and isclass(get_args(fld.type)[0])
+                and issubclass(get_args(fld.type)[0], Header)
+            ):
                 attr_items[fld.name] = get_args(fld.type)[0].empty()
             elif (
                 get_origin(fld.type) is list
@@ -277,7 +280,7 @@ class Header:
                 and issubclass(get_args(fld.type)[0], Header)
             ):
                 attr_items[fld.name] = [get_args(fld.type)[0].empty()]
-            elif (get_origin(fld.type) is list):
+            elif get_origin(fld.type) is list:
                 attr_items[fld.name] = []
             else:
                 attr_items[fld.name] = None

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -425,7 +425,7 @@ class Person(Header):
     """
 
     name: str
-    affiliation: Union[str, List[str]]
+    affiliation: Union[List[str], str]
     contact: Optional[str] = field(default=None, metadata={"description": "Contact (email) address"})
 
 

--- a/orsopy/fileio/data_source.py
+++ b/orsopy/fileio/data_source.py
@@ -61,8 +61,8 @@ class Sample(Header):
     name: str
     category: Optional[str] = None
     composition: Optional[str] = None
-    description: Optional[Union[str, List]] = None
-    environment: Optional[Union[str, List[str]]] = None
+    description: Optional[Union[list, str]] = None
+    environment: Optional[Union[List[str], str]] = None
     sample_parameters: Optional[Dict] = field(
         default=None, metadata={"description": "Using keys for parameters and Value* objects for values."}
     )

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -67,7 +67,7 @@ class Orso(Header):
         :return: Empty Orso class, within minimum required columns
         """
         res = super(Orso, cls).empty()
-        res.columns = [Column('Qz', '1/angstrom'), Column('R')]
+        res.columns = [Column("Qz", "1/angstrom"), Column("R")]
         return res
 
     @property

--- a/tests/test_fileio/test_base.py
+++ b/tests/test_fileio/test_base.py
@@ -4,11 +4,12 @@ Tests for fileio.base module
 # pylint: disable=R0201
 
 import pathlib
-from os.path import join as pjoin
 import unittest
-import pytest
 
 from datetime import datetime
+from os.path import join as pjoin
+
+import pytest
 
 from numpy.testing import assert_equal
 
@@ -316,7 +317,5 @@ class TestFile(unittest.TestCase):
 
 
 def test_not_orso():
-    with pytest.raises(
-            base.NotOrsoCompatibleFileError, match="First line does not appea"
-    ):
+    with pytest.raises(base.NotOrsoCompatibleFileError, match="First line does not appea"):
         orso.load_orso(pjoin("tests", "not_orso.ort"))

--- a/tests/test_fileio/test_base.py
+++ b/tests/test_fileio/test_base.py
@@ -180,6 +180,11 @@ class TestPerson(unittest.TestCase):
         assert value.affiliation == "Ivy League University"
         assert value.contact == "jauser@ivy.edu"
 
+    def test_creation_with_list(self):
+        value = base.Person("Joe A. User", ["Ivy League University", "Great Neutron Factory"])
+        assert value.name == "Joe A. User"
+        assert value.affiliation == ["Ivy League University", "Great Neutron Factory"]
+
     def test_to_yaml(self):
         """
         Transform to yaml with no email.

--- a/tests/test_fileio/test_data_source.py
+++ b/tests/test_fileio/test_data_source.py
@@ -145,6 +145,17 @@ class TestSample(unittest.TestCase):
             + "environment: Temperature cell\n"
         )
 
+    def test_creation_lists(self):
+        # description can be List[any], enironment List[str]
+        value = data_source.Sample(
+            "A Perfect Sample",
+            description=["The sample is without flaws", "now it got scratched", 314.2, 41],
+            environment=["Temperature cell", "Super magnet"],
+        )
+        assert value.name == "A Perfect Sample"
+        assert value.description == ["The sample is without flaws", "now it got scratched", 314.2, 41]
+        assert value.environment == ["Temperature cell", "Super magnet"]
+
 
 class TestDataSource(unittest.TestCase):
     """

--- a/tests/test_fileio/test_data_source.py
+++ b/tests/test_fileio/test_data_source.py
@@ -185,10 +185,7 @@ class TestInstrumentSettings(unittest.TestCase):
         """
         Creation with minimal settings.
         """
-        value = data_source.InstrumentSettings(
-            base.Value(4.0, "deg"),
-            base.ValueRange(2.0, 12.0, "angstrom"),
-        )
+        value = data_source.InstrumentSettings(base.Value(4.0, "deg"), base.ValueRange(2.0, 12.0, "angstrom"),)
         assert value.incident_angle.magnitude == 4.0
         assert value.incident_angle.unit == "deg"
         assert value.wavelength.min == 2.0
@@ -201,10 +198,7 @@ class TestInstrumentSettings(unittest.TestCase):
         """
         Transformation to yaml with minimal set.
         """
-        value = data_source.InstrumentSettings(
-            base.Value(4.0, "deg"),
-            base.ValueRange(2.0, 12.0, "angstrom"),
-        )
+        value = data_source.InstrumentSettings(base.Value(4.0, "deg"), base.ValueRange(2.0, 12.0, "angstrom"),)
         assert (
             value.to_yaml()
             == "incident_angle:\n  magnitude: "
@@ -259,10 +253,7 @@ class TestMeasurement(unittest.TestCase):
         Creation with minimal set.
         """
         value = data_source.Measurement(
-            data_source.InstrumentSettings(
-                base.Value(4.0, "deg"),
-                base.ValueRange(2.0, 12.0, "angstrom"),
-            ),
+            data_source.InstrumentSettings(base.Value(4.0, "deg"), base.ValueRange(2.0, 12.0, "angstrom"),),
             [base.File(str(pathlib.Path().resolve().joinpath("README.rst")), None)],
         )
         assert value.instrument_settings.incident_angle.magnitude == 4.0
@@ -278,10 +269,7 @@ class TestMeasurement(unittest.TestCase):
         Transform to yaml with minimal set.
         """
         value = data_source.Measurement(
-            data_source.InstrumentSettings(
-                base.Value(4.0, "deg"),
-                base.ValueRange(2.0, 12.0, "angstrom"),
-            ),
+            data_source.InstrumentSettings(base.Value(4.0, "deg"), base.ValueRange(2.0, 12.0, "angstrom"),),
             [base.File(str(pathlib.Path().resolve().joinpath("README.rst")), None)],
         )
         fname = pathlib.Path("README.rst")
@@ -300,10 +288,7 @@ class TestMeasurement(unittest.TestCase):
         Creation with optionals.
         """
         value = data_source.Measurement(
-            data_source.InstrumentSettings(
-                base.Value(4.0, "deg"),
-                base.ValueRange(2.0, 12.0, "angstrom"),
-            ),
+            data_source.InstrumentSettings(base.Value(4.0, "deg"), base.ValueRange(2.0, 12.0, "angstrom"),),
             [base.File(str(pathlib.Path().resolve().joinpath("README.rst")), None)],
             [base.File(str(pathlib.Path().resolve().joinpath("AUTHORS.rst")), None)],
         )
@@ -322,10 +307,7 @@ class TestMeasurement(unittest.TestCase):
         Transform to yaml with optionals.
         """
         value = data_source.Measurement(
-            data_source.InstrumentSettings(
-                base.Value(4.0, "deg"),
-                base.ValueRange(2.0, 12.0, "angstrom"),
-            ),
+            data_source.InstrumentSettings(base.Value(4.0, "deg"), base.ValueRange(2.0, 12.0, "angstrom"),),
             [base.File(str(pathlib.Path().resolve().joinpath("README.rst")), None)],
             [base.File(str(pathlib.Path().resolve().joinpath("AUTHORS.rst")), None)],
             "energy-dispersive",

--- a/tests/test_fileio/test_orso.py
+++ b/tests/test_fileio/test_orso.py
@@ -251,7 +251,7 @@ class TestFunctions(unittest.TestCase):
         assert ds.sample.name is None
         assert ds.measurement.instrument_settings.incident_angle.magnitude is None
         assert ds.measurement.instrument_settings.wavelength.magnitude is None
-        assert ds.measurement.data_files is None
+        assert ds.measurement.data_files == []
         assert empty.reduction.software.name is None
         assert empty.reduction.software.version is None
         assert empty.reduction.software.platform is None
@@ -274,13 +274,13 @@ class TestFunctions(unittest.TestCase):
         """
         empty = Orso.empty()
         req = (
-            'data_source:\n  owner:\n    name: null\n'
-            '    affiliation: null\n  experiment:\n    title: null\n'
-            '    instrument: null\n    start_date: null\n    probe: null\n'
-            '  sample:\n    name: null\n  measurement:\n'
-            '    instrument_settings:\n      incident_angle:\n        magnitude: null\n'
-            '      wavelength:\n        magnitude: null\n      polarization: unpolarized\n'
-            '    data_files: null\nreduction:\n  software:\n    name: null\n'
-            'columns:\n- name: Qz\n  unit: 1/angstrom\n- name: R\n'
+            "data_source:\n  owner:\n    name: null\n"
+            "    affiliation: null\n  experiment:\n    title: null\n"
+            "    instrument: null\n    start_date: null\n    probe: null\n"
+            "  sample:\n    name: null\n  measurement:\n"
+            "    instrument_settings:\n      incident_angle:\n        magnitude: null\n"
+            "      wavelength:\n        magnitude: null\n      polarization: unpolarized\n"
+            "    data_files: []\nreduction:\n  software:\n    name: null\n"
+            "columns:\n- name: Qz\n  unit: 1/angstrom\n- name: R\n"
         )
         assert empty.to_yaml() == req

--- a/tests/test_fileio/test_orso.py
+++ b/tests/test_fileio/test_orso.py
@@ -124,11 +124,7 @@ class TestOrso(unittest.TestCase):
 
         info3 = fileio.Orso(
             data_source=fileio.DataSource(
-                sample=fileio.Sample(
-                    name="My Sample",
-                    category="solid",
-                    description="Something descriptive",
-                ),
+                sample=fileio.Sample(name="My Sample", category="solid", description="Something descriptive",),
                 experiment=fileio.Experiment(
                     title="Main experiment",
                     instrument="Reflectometer",
@@ -138,8 +134,7 @@ class TestOrso(unittest.TestCase):
                 owner=fileio.Person("someone", "important"),
                 measurement=fileio.Measurement(
                     instrument_settings=fileio.InstrumentSettings(
-                        incident_angle=fileio.Value(13.4, "deg"),
-                        wavelength=fileio.Value(5.34, "A"),
+                        incident_angle=fileio.Value(13.4, "deg"), wavelength=fileio.Value(5.34, "A"),
                     ),
                     data_files=["abc", "def", "ghi"],
                     references=["more", "files"],


### PR DESCRIPTION
The current version leads to wrong generation of lists as strings, this should fix it.

```python
from orsopy import fileio
fileio.Sample(name='bier', category='beverage',  description=['abc', 23.4, 2],  environment=['glass', 'table'])

output before:
>> Sample(name='bier', category='beverage', description="['abc', 23.4, 2]", environment="['glass', 'table']")

ouput after:
>> Sample(name='bier', category='beverage', description=['abc', 23.4, 2], environment=['glass', 'table'])

```

Some autoformatting was introduced by black/isort.