### PR TITLE
Release version 0.0.5

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,8 +2,14 @@
 History
 =======
 
+0.0.5 (2022-02-04)
+------------------
+
+* Merge the slddb package into orsopy for simple query of the database.
+  SLD db will transition to orsopy for its backend.
+
 0.0.4 (2022-01-19)
---------
+------------------
 
 * Fix a bug prventing usage of fileio on python >=3.10.1 due to changes in dataclasses internal API
 * Replace the metaclass implementation by a decorator behaving similar to dataclass
@@ -12,7 +18,7 @@ History
 * More documentation improvements
 
 0.0.3 (2021-11-14)
---------
+------------------
 
 * Implement user_data from custom keyword arguments
 * Improvements to documentation
@@ -20,7 +26,7 @@ History
 * Allow user defined spaces between multiple datasets
 
 0.0.2 (2021-10-08)
---------
+------------------
 
 * Integration of PyPI with Github build system
 

--- a/orsopy/__init__.py
+++ b/orsopy/__init__.py
@@ -1,3 +1,3 @@
 """Top-level package for orsopy."""
 
-__version__ = "0.0.4"
+__version__ = "0.0.5"


### PR DESCRIPTION
To be able to transition SLD db to orsopy I'm releasing this version.