### PR TITLE
Implement YAML export with more flexibility in output layout per Header class

### DIFF
--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -139,6 +139,14 @@ class Orso(Header):
         out["columns"] = cols
         return out
 
+    def _to_object_dict(self):
+        out = super()._to_object_dict()
+        out.update(self._user_data)
+        # put columns at the end of the dictionary
+        cols = out.pop("columns")
+        out["columns"] = cols
+        return out
+
 
 @dataclass
 class OrsoDataset:

--- a/tests/test_fileio/test_base.py
+++ b/tests/test_fileio/test_base.py
@@ -49,14 +49,14 @@ class TestValue(unittest.TestCase):
         Transform to yaml.
         """
         value = base.Value(1.0, "m")
-        assert value.to_yaml() == "magnitude: 1.0\nunit: m\n"
+        assert value.to_yaml() == "{magnitude: 1.0, unit: m}\n"
 
     def test_no_magnitude_to_yaml(self):
         """
         Transform to yaml with a non-optional ORSO item.
         """
         value = base.Value(None)
-        assert value.to_yaml() == "magnitude: null\n"
+        assert value.to_yaml() == "{magnitude: null}\n"
 
 
 class TestValueVector(unittest.TestCase):
@@ -141,21 +141,21 @@ class TestValueRange(unittest.TestCase):
         Transform to yaml.
         """
         value = base.ValueRange(1.0, 2.0, "m")
-        assert value.to_yaml() == "min: 1.0\nmax: 2.0\nunit: m\n"
+        assert value.to_yaml() == "{min: 1.0, max: 2.0, unit: m}\n"
 
     def test_no_upper_to_yaml(self):
         """
         Transform to yaml with no max.
         """
         value = base.ValueRange(1.0, None)
-        assert value.to_yaml() == "min: 1.0\nmax: null\n"
+        assert value.to_yaml() == "{min: 1.0, max: null}\n"
 
     def test_no_lower_to_yaml(self):
         """
         Transform to yaml with no min.
         """
         value = base.ValueRange(None, 1.0)
-        assert value.to_yaml() == "min: null\nmax: 1.0\n"
+        assert value.to_yaml() == "{min: null, max: 1.0}\n"
 
 
 class TestPerson(unittest.TestCase):
@@ -242,14 +242,14 @@ class TestColumn(unittest.TestCase):
         Transformation to yaml.
         """
         value = base.Column("q", "1/angstrom", "qz vector")
-        assert value.to_yaml() == "name: q\nunit: 1/angstrom\ndimension: qz vector\n"
+        assert value.to_yaml() == "{name: q, unit: 1/angstrom, dimension: qz vector}\n"
 
     def test_no_description_to_yaml(self):
         """
         Transformation to yaml.
         """
         value = base.Column("q", "1/angstrom")
-        assert value.to_yaml() == "name: q\nunit: 1/angstrom\n"
+        assert value.to_yaml() == "{name: q, unit: 1/angstrom}\n"
 
 
 class TestFile(unittest.TestCase):

--- a/tests/test_fileio/test_data_source.py
+++ b/tests/test_fileio/test_data_source.py
@@ -212,9 +212,9 @@ class TestInstrumentSettings(unittest.TestCase):
         value = data_source.InstrumentSettings(base.Value(4.0, "deg"), base.ValueRange(2.0, 12.0, "angstrom"),)
         assert (
             value.to_yaml()
-            == "incident_angle:\n  magnitude: "
-            + "4.0\n  unit: deg\nwavelength:\n  min: 2.0\n  "
-            + "max: 12.0\n  unit: angstrom\npolarization: unpolarized\n"
+            == "incident_angle: {magnitude: 4.0, unit: deg}\n"
+            + "wavelength: {min: 2.0, max: 12.0, unit: angstrom}\n"
+            + "polarization: unpolarized\n"
         )
 
     def test_creation_config_and_polarization(self):
@@ -247,9 +247,9 @@ class TestInstrumentSettings(unittest.TestCase):
         )
         assert (
             value.to_yaml()
-            == "incident_angle:\n  magnitude: "
-            + "4.0\n  unit: deg\nwavelength:\n  min: 2.0\n  "
-            + "max: 12.0\n  unit: angstrom\npolarization: p\n"
+            == "incident_angle: {magnitude: 4.0, unit: deg}\n"
+            + "wavelength: {min: 2.0, max: 12.0, unit: angstrom}\n"
+            + "polarization: p\n"
             + "configuration: liquid surface\n"
         )
 
@@ -287,8 +287,8 @@ class TestMeasurement(unittest.TestCase):
         assert (
             value.to_yaml()
             == "instrument_settings:\n  incident_angle:"
-            + "\n    magnitude: 4.0\n    unit: deg\n  wavelength:\n    min: "
-            + "2.0\n    max: 12.0\n    unit: angstrom\n  polarization: "
+            + " {magnitude: 4.0, unit: deg}\n  wavelength: {min: "
+            + "2.0, max: 12.0, unit: angstrom}\n  polarization: "
             + "unpolarized\ndata_files:\n- file: "
             + f"{str(fname.absolute())}\n  timestamp: "
             + f"{datetime.fromtimestamp(fname.stat().st_mtime).isoformat()}\n"
@@ -328,8 +328,8 @@ class TestMeasurement(unittest.TestCase):
         assert (
             value.to_yaml()
             == "instrument_settings:\n  incident_angle:"
-            + "\n    magnitude: 4.0\n    unit: deg\n  wavelength:\n    min: "
-            + "2.0\n    max: 12.0\n    unit: angstrom\n  polarization: "
+            + " {magnitude: 4.0, unit: deg}\n  wavelength: {min: "
+            + "2.0, max: 12.0, unit: angstrom}\n  polarization: "
             + "unpolarized\ndata_files:\n- file: "
             + f"{str(fname.absolute())}\n  timestamp: "
             + f"{datetime.fromtimestamp(fname.stat().st_mtime).isoformat()}\n"

--- a/tests/test_fileio/test_orso.py
+++ b/tests/test_fileio/test_orso.py
@@ -278,9 +278,9 @@ class TestFunctions(unittest.TestCase):
             "    affiliation: null\n  experiment:\n    title: null\n"
             "    instrument: null\n    start_date: null\n    probe: null\n"
             "  sample:\n    name: null\n  measurement:\n"
-            "    instrument_settings:\n      incident_angle:\n        magnitude: null\n"
-            "      wavelength:\n        magnitude: null\n      polarization: unpolarized\n"
+            "    instrument_settings:\n      incident_angle: {magnitude: null}\n"
+            "      wavelength: {magnitude: null}\n      polarization: unpolarized\n"
             "    data_files: []\nreduction:\n  software:\n    name: null\n"
-            "columns:\n- name: Qz\n  unit: 1/angstrom\n- name: R\n"
+            "columns:\n- {name: Qz, unit: 1/angstrom}\n- {name: R}\n"
         )
         assert empty.to_yaml() == req


### PR DESCRIPTION
This PR implements an improved approach to perform the export to YAML. It uses a custom yaml.SafeDumper derived class to call the yaml_representer method for each Header derived item. 

This allows for a simple and transparent way to customize the way the YAML representation is layed out. The current use case is to toggle between compact and expanded representation of the dictionary to allow the Value, ValueRange and Column items to be displayed in a single line for a more compact and readable header. 

More specific classes might use it in the future for more control about e.g. sorting of items, indentation or multiline strings. It might come handy for some of the simple model description, too.

Previous empty header:
``` YAML
data_source:
  owner:
    name: null
    affiliation: null
  experiment:
    title: null
    instrument: null
    start_date: null
    probe: null
  sample:
    name: null
  measurement:
    instrument_settings:
      incident_angle:
        magnitude: null
      wavelength:
        magnitude: null
      polarization: p
    data_files: []
reduction:
  software:
    name: null
data_set: up polarization
columns:
- name: Qz
  unit: 1/angstrom
- name: R
- name: sR
```

New empty header:
``` YAML
data_source:
  owner:
    name: null
    affiliation: null
  experiment:
    title: null
    instrument: null
    start_date: null
    probe: null
  sample:
    name: null
  measurement:
    instrument_settings:
      incident_angle: {magnitude: null}
      wavelength: {magnitude: null}
      polarization: p
    data_files: []
reduction:
  software:
    name: null
data_set: up polarization
columns:
- {name: Qz, unit: 1/angstrom}
- {name: R}
- {name: sR}
```