### PR TITLE
To nexus

### DIFF
--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -450,14 +450,6 @@ class Value(Header):
 
     yaml_representer = Header.yaml_representer_compact
 
-    def to_nexus(self, root, name):
-        group = root.create_group(name)
-        group.create_dataset("magnitude", dtype=float, data=self.magnitude)
-        if self.unit is not None:
-            print("unit", self.unit)
-            group.create_dataset("unit", data=self.unit)
-        return group
-
 
 @orsodataclass
 class ValueRange(Header):
@@ -471,14 +463,6 @@ class ValueRange(Header):
 
     yaml_representer = Header.yaml_representer_compact
 
-    def to_nexus(self, root, name):
-        group = root.create_group(name)
-        group.create_dataset("min", dtype=float, data=self.min)
-        group.create_dataset("max", dtype=float, data=self.max)
-        if self.unit is not None:
-            print("unit", self.unit)
-            group.create_dataset("unit", data=self.unit)
-        return group
 
 @orsodataclass
 class ValueVector(Header):

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -359,9 +359,7 @@ class Header:
             if child_name.startswith("_") or (value is None and child_name in self._orso_optionals):
                 continue
 
-            if isinstance(value, Column):
-                pass
-            elif value.__class__ in ORSO_DATACLASSES.values():
+            if value.__class__ in ORSO_DATACLASSES.values():
                 value.to_nexus(root=group, name=child_name)
             elif isinstance(value, (list, tuple)):
                 child_group = group.create_group(child_name)

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -597,7 +597,7 @@ def _read_header_data(file: Union[TextIO, str], validate: bool = False) -> Tuple
                 # numerical array  and start collecting the numbers for this
                 # dataset
                 _d = np.array([np.fromstring(v, dtype=float, sep=" ") for v in _ds_lines])
-                data.append(_d)
+                data.append(_d.T)
                 _ds_lines = []
 
                 # append '---' to signify the start of a new yaml document
@@ -610,7 +610,7 @@ def _read_header_data(file: Union[TextIO, str], validate: bool = False) -> Tuple
 
         # append the last numerical array
         _d = np.array([np.fromstring(v, dtype=float, sep=" ") for v in _ds_lines])
-        data.append(_d)
+        data.append(_d.T)
 
         yml = "".join(header)
 

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -80,7 +80,9 @@ def _custom_init_fn(fieldsarg, frozen, has_post_init, self_name, globals):
         return_type=None,
     )
 
+
 ORSO_DATACLASSES = set()
+
 
 def orsodataclass(cls: type):
     ORSO_DATACLASSES.add(cls)
@@ -378,7 +380,6 @@ class Header:
                 else:
                     group.create_dataset(child_name, data=json.dumps(_todict(value), default=json_datetime_trap))
         return group
-
 
     @staticmethod
     def _check_unit(unit: str):
@@ -735,10 +736,12 @@ def _todict(obj: Any, classkey: Any = None) -> dict:
     else:
         return obj
 
+
 def json_datetime_trap(obj):
     if isinstance(obj, datetime.datetime):
         return obj.isoformat()
     return obj
+
 
 def _nested_update(d: dict, u: dict) -> dict:
     """

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -344,6 +344,9 @@ def save_nexus(datasets: List[OrsoDataset], fname: Union[str, BinaryIO], comment
             data_group = entry.create_group("data")
             data_group.attrs["NX_class"] = "NXdata"
             data_group.attrs["list"] = 1
+            data_group.attrs["axes"] = [info.columns[0].name]
+            data_group.attrs["signal"] = info.columns[1].name
+            data_group.attrs[f"{info.columns[0].name}_indices"] = [0]
             for column_index, column in enumerate(info.columns):
                 # assume that dataset.data has dimension == ncolumns along first dimension
                 # (note that this is not how data would be loaded from e.g. load_orso, which is row-first)

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -294,7 +294,7 @@ def save_nexus(datasets: List[OrsoDataset], fname: Union[str, BinaryIO], comment
             entry = f.create_group(info.data_set)
             entry.attrs["ORSO_class"] = "OrsoDataset"
             entry.attrs["NX_class"] = "NXentry"
-            info_group = info.to_nexus(root=entry, name="info")
+            info.to_nexus(root=entry, name="info")
             data_group = entry.create_group("data")
             data_group.attrs["NX_class"] = "NXdata"
             for column_index, column in enumerate(info.columns):

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -163,8 +163,11 @@ class OrsoDataset:
     data: Any
 
     def __post_init__(self):
-        if self.data.shape[1] != len(self.info.columns):
+        if len(self.data) != len(self.info.columns):
             raise ValueError("Data has to have the same number of columns as header")
+        column_lengths = set(len(c) for c in self.data)
+        if len(column_lengths) > 1:
+            raise ValueError("Columns must all have the same length in first dimension")
 
     def header(self) -> str:
         """
@@ -249,13 +252,13 @@ def save_orso(
 
         ds1 = datasets[0]
         header += ds1.header()
-        np.savetxt(f, ds1.data, header=header, fmt="%-22.16e")
+        np.savetxt(f, ds1.data.T, header=header, fmt="%-22.16e")
 
         for dsi in datasets[1:]:
             # write an optional spacer string between dataset e.g. \n
             f.write(data_separator)
             hi = ds1.diff_header(dsi)
-            np.savetxt(f, dsi.data, header=hi, fmt="%-22.16e")
+            np.savetxt(f, dsi.data.T, header=hi, fmt="%-22.16e")
 
 
 def load_orso(fname: Union[TextIO, str]) -> List[OrsoDataset]:

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -291,11 +291,12 @@ def save_nexus(datasets: List[OrsoDataset], fname: Union[str, BinaryIO], comment
 
         for dsi in datasets:
             info = dsi.info
-            entry = info.to_nexus(f, name=info.data_set)
+            entry = f.create_group(info.data_set)
+            entry.attrs["ORSO_class"] = "OrsoDataset"
             entry.attrs["NX_class"] = "NXentry"
+            info_group = info.to_nexus(root=entry, name="info")
             data_group = entry.create_group("data")
             data_group.attrs["NX_class"] = "NXdata"
-            data_group.attrs["ORSO_class"] = "dataset"
             for column_index, column in enumerate(info.columns):
                 # assume that dataset.data has dimension == ncolumns along first dimension
                 # (note that this is not how data would be loaded from e.g. load_orso, which is row-first)

--- a/tests/make_nx.py
+++ b/tests/make_nx.py
@@ -1,0 +1,10 @@
+import os
+from orsopy.fileio import load_orso
+from orsopy.fileio.orso import save_nexus
+
+currdir = os.path.dirname(__file__)
+ex = load_orso(os.path.join(currdir, "test_example2.ort"))
+# for entry in ex:
+#    entry.data = entry.data.T
+
+save_nexus(ex, os.path.join(currdir, "test_nexus.orb"))

--- a/tests/test_fileio/test_orso.py
+++ b/tests/test_fileio/test_orso.py
@@ -104,8 +104,8 @@ class TestOrso(unittest.TestCase):
         # test write and read of multiple datasets
         info = fileio.Orso.empty()
         info2 = fileio.Orso.empty()
-        data = np.zeros((100, 3))
-        data[:] = np.arange(100.0)[:, None]
+        data = np.zeros((3, 100))
+        data[:] = np.arange(100.0)[None, :]
 
         info.columns = [
             fileio.Column("Qz", "1/angstrom"),
@@ -177,14 +177,14 @@ class TestOrso(unittest.TestCase):
         info2.data_set = 0
         info2.columns = [Column("stuff")] * 4
 
-        ds = OrsoDataset(info, np.empty((2, 4)))
-        ds2 = OrsoDataset(info2, np.empty((2, 4)))
+        ds = OrsoDataset(info, np.empty((4, 2)))
+        ds2 = OrsoDataset(info2, np.empty((4, 2)))
 
         with pytest.raises(ValueError):
             fileio.save_orso([ds, ds2], "test_data_set.ort")
 
         with pytest.raises(ValueError):
-            OrsoDataset(info, np.empty((2, 5)))
+            OrsoDataset(info, np.empty((5, 2)))
 
     def test_user_data(self):
         # test write and read of userdata
@@ -195,8 +195,8 @@ class TestOrso(unittest.TestCase):
             fileio.Column("sR"),
         ]
 
-        data = np.zeros((100, 3))
-        data[:] = np.arange(100.0)[:, None]
+        data = np.zeros((3, 100))
+        data[:] = np.arange(100.0)[None, :]
         dct = {"ci": "1", "foo": ["bar", 1, 2, 3.5]}
         info.user_data = dct
         ds = fileio.OrsoDataset(info, data)

--- a/tests/test_fileio/test_schema.py
+++ b/tests/test_fileio/test_schema.py
@@ -17,7 +17,7 @@ class TestSchema:
             schema = json.load(f)
 
         dct_list, data, version = _read_header_data(os.path.join("tests", "test_example.ort"), validate=True)
-        assert data[0].shape == (2, 4)
+        assert data[0].shape == (4, 2)
         assert version == "0.1"
 
         # d contains datetime.datetime objects, which would fail the
@@ -33,4 +33,4 @@ class TestSchema:
         assert len(dct_list) == 2
         assert dct_list[1]["data_set"] == "spin_down"
         assert data[1].shape == (4, 4)
-        np.testing.assert_allclose(data[1][2:], data[0])
+        np.testing.assert_allclose(data[1][:, 2:], data[0])

--- a/tools/header_schema.py
+++ b/tools/header_schema.py
@@ -23,8 +23,7 @@ class PydanticConfig:
                 value['enum'].append(None)
 
             if 'type' in value:
-                value['anyOf'] = [{'type': value.pop('type')}]
-                value['anyOf'].append({'type': 'null'})
+                value['type'] = [value.pop('type'), "null"]
             elif "anyOf" in value:
                 value['anyOf'].append({'type': 'null'})
             # only one $ref e.g. from other model


### PR DESCRIPTION
Adding some support for writing a nexus file (experimental).
This PR is not meant to be accepted without significant discussion and editing.

Notes:

- In nexus, information is stored in attributes or fields.  In the HDF5 file, you can store the same types of data in both places, the difference is one of convention.  In the ORSO header classes, there is no obvious hierarchy to the class attributes, so to first order they should either all be attributes or all fields in the HDF version (I chose fields)
- The data loaded by load_orso has shape (rows, columns), which makes it hard to write column-oriented data to HDF (have to loop over non-first index).  It might make more sense to have the default order of OrsoDataset.data be (columns, rows) instead. In many cases OrsoDataset.data might not be a single ndarray at all, but rather an iterable (list, tuple...) of arrays with arbitrary dimension, but the first dimension within each column should always be rows, e.g. OrsoDataset.data = [array(rows, 2, 2), array(rows), array(rows, 5)].  This would then work transparently if an ndarray of shape (columns, rows) was passed in, as numpy will happily iterate over the first dimension.
- There is no currently no linking between Orso.columns in the "header" and the actual data in the ```data``` group.  I'm not sure you need a "columns" section in the metadata of the HDF5 file if you can add all the attributes from the Orso.columns list to the data directly.  Otherwise we could just make a soft link between the Column metadata and the data in ```data```.

I'm attaching the test_example2.ort file loaded and then saved as nexus
```python
from orsopy.fileio import load_orso
from orsopy.fileio.orso import save_nexus

ex = load_orso("./test_example2.ort")
for entry in ex:
    entry.data = entry.data.T

save_nexus(ex, "test_nexus.orb")
```
[test_nexus.zip](https://github.com/reflectivity/orsopy/files/8208934/test_nexus.zip)
