### PR TITLE
Unit conversion for Values

### DIFF
--- a/orsopy/fileio/__init__.py
+++ b/orsopy/fileio/__init__.py
@@ -2,7 +2,8 @@
 Implementation of the Orso class that defined the header.
 """
 
-from .base import Column, File, Header, Person, Value, ValueRange, ValueVector, _read_header_data, _validate_header_data
+from .base import (Column, ComplexValue, File, Header, Person, Value, ValueRange, ValueVector, _read_header_data,
+                   _validate_header_data)
 from .data_source import DataSource, Experiment, InstrumentSettings, Measurement, Sample
 from .orso import ORSO_VERSION, Orso, OrsoDataset, load_orso, save_orso
 from .reduction import Reduction, Software

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -194,7 +194,7 @@ class Header:
                 except ValueError:
                     # string wasn't ISO8601 format
                     return None
-            if issubclass(hint, Header) and hasattr(item, "keys"):
+            if issubclass(hint, Header) and isinstance(item, dict):
                 # convert to dataclass instance
                 attribs = hint.__annotations__.keys()
                 realised_items = {k: item[k] for k in item.keys() if k in attribs}

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -410,6 +410,29 @@ class Value(Header):
 
 
 @orsodataclass
+class ComplexValue(Header):
+    """
+    A value or list of values with an optional unit.
+    """
+
+    real: Union[float, List[float]]
+    imag: Optional[Union[float, List[float]]] = 0.0
+    unit: Optional[str] = field(default=None, metadata={"description": "SI unit string"})
+
+    yaml_representer = Header.yaml_representer_compact
+
+    def __repr__(self):
+        """
+        Make representation more readability by removing names of default arguments.
+        """
+        output = super().__repr__()
+        output = output.replace("real=", "")
+        output = output.replace("imag=", "")
+        output = output.replace("unit=", "")
+        return output
+
+
+@orsodataclass
 class ValueRange(Header):
     """
     A range or list of ranges with mins, maxs, and an optional unit.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,4 +13,4 @@ jsonschema>=3.2.0
 typing_extensions
 coverage
 coveralls
-pint>=0.18
+pint

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,3 +13,4 @@ jsonschema>=3.2.0
 typing_extensions
 coverage
 coveralls
+pint>=0.18


### PR DESCRIPTION
This PR adds a ComplexValue class and implements unit conversions via pint library for all Value objects. This was partially introduced in the model language PR but I think it makes sense to add this functionality to the library, anyway.