### PR TITLE
Release version 1.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,14 @@
 History
 =======
 
-0.1.0 (2022-06-08)
+1.0.0 (2022-06-10)
+------------------
+
+* ORSO general assembly has voted to release the first version of orsopy together with the
+  text representation of the text file (.ort) specification.
+  See https://www.reflectometry.org/workshops/workshop_2022/
+
+0.1.1 (2022-06-08)
 ------------------
 
 * Fix missing data files in distribution

--- a/orsopy/__init__.py
+++ b/orsopy/__init__.py
@@ -1,3 +1,3 @@
 """Top-level package for orsopy."""
 
-__version__ = "0.1.1"
+__version__ = "1.0.0"

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -13,7 +13,7 @@ from .base import (Column, ErrorColumn, Header, _dict_diff, _nested_update, _pos
 from .data_source import DataSource
 from .reduction import Reduction
 
-ORSO_VERSION = "0.1"
+ORSO_VERSION = "1.0"
 ORSO_DESIGNATE = (
     f"# ORSO reflectivity data file | {ORSO_VERSION} standard " "| YAML encoding | https://www.reflectometry.org/"
 )

--- a/orsopy/fileio/schema/refl_header.schema.json
+++ b/orsopy/fileio/schema/refl_header.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/reflectivity/orsopy/v0.1/orsopy/fileio/schema/refl_header.schema.json",
+  "$id": "https://raw.githubusercontent.com/reflectivity/orsopy/v1.0/orsopy/fileio/schema/refl_header.schema.json",
   "title": "Orso",
   "type": "object",
   "properties": {
@@ -507,7 +507,7 @@
           ]
         },
         "polarization": {
-          "description": "Polarization described as unpolarized/ p / m / pp / pm / mp / mm / vector",
+          "description": "Polarization described as unpolarized/ po/ mo / op / om / pp / pm / mp / mm / vector",
           "anyOf": [
             {
               "$ref": "#/definitions/Polarization"

--- a/orsopy/fileio/schema/refl_header.schema.yaml
+++ b/orsopy/fileio/schema/refl_header.schema.yaml
@@ -1,4 +1,4 @@
-$id: https://raw.githubusercontent.com/reflectivity/orsopy/v0.1/orsopy/fileio/schema/refl_header.schema.json
+$id: https://raw.githubusercontent.com/reflectivity/orsopy/v1.0/orsopy/fileio/schema/refl_header.schema.json
 $schema: http://json-schema.org/draft-07/schema#
 definitions:
   Column:
@@ -178,8 +178,8 @@ definitions:
         - $ref: '#/definitions/Polarization'
         - $ref: '#/definitions/ValueVector'
         - type: 'null'
-        description: Polarization described as unpolarized/ p / m / pp / pm / mp /
-          mm / vector
+        description: Polarization described as unpolarized/ po/ mo / op / om / pp
+          / pm / mp / mm / vector
       wavelength:
         anyOf:
         - $ref: '#/definitions/Value'

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Topic :: Scientific/Engineering
-    Development Status :: 4 - Beta
+    Development Status :: 5 - Production/Stable
 
 [options]
 python_requires = >=3.8


### PR DESCRIPTION
 Following approval by ORSO GA, release the first stable version/file specification.

https://www.reflectometry.org/workshops/workshop_2022/

![image](https://user-images.githubusercontent.com/4118730/173092721-c5393013-3aad-4485-98ca-1aef21158e16.png)
