### PR TITLE
Update ort spec from GA comments

### DIFF
--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -496,8 +496,8 @@ class ComplexValue(Header):
     A value or list of values with an optional unit.
     """
 
-    real: Union[float, List[float]]
-    imag: Optional[Union[float, List[float]]] = None
+    real: float
+    imag: Optional[float] = None
     unit: Optional[str] = field(default=None, metadata={"description": "SI unit string"})
     error: Optional[ErrorValue] = None
 

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -439,6 +439,20 @@ unit_registry = None
 
 
 @orsodataclass
+class ErrorValue(Header):
+    """
+    Information about errors on a value.
+    """
+
+    error_value: float
+    error_type: Optional[Literal["uncertainty", "resolution"]] = None
+    value_is: Optional[Literal["sigma", "FWHM"]] = None
+    distribution: Optional[Literal["gaussian", "triangular", "uniform", "lorentzian"]] = None
+
+    yaml_representer = Header.yaml_representer_compact
+
+
+@orsodataclass
 class Value(Header):
     """
     A value or list of values with an optional unit.
@@ -446,6 +460,7 @@ class Value(Header):
 
     magnitude: float
     unit: Optional[str] = field(default=None, metadata={"description": "SI unit string"})
+    error: Optional[ErrorValue] = None
 
     yaml_representer = Header.yaml_representer_compact
 
@@ -484,6 +499,7 @@ class ComplexValue(Header):
     real: Union[float, List[float]]
     imag: Optional[Union[float, List[float]]] = None
     unit: Optional[str] = field(default=None, metadata={"description": "SI unit string"})
+    error: Optional[ErrorValue] = None
 
     yaml_representer = Header.yaml_representer_compact
 
@@ -567,6 +583,7 @@ class ValueVector(Header):
     y: float
     z: float
     unit: Optional[str] = field(default=None, metadata={"description": "SI unit string"})
+    error: Optional[ErrorValue] = None
 
     def as_unit(self, output_unit):
         """

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -607,7 +607,9 @@ class Column(Header):
 
     name: str
     unit: Optional[str] = field(default=None, metadata={"description": "SI unit string"})
-    dimension: Optional[str] = field(default=None, metadata={"dimension": "A description of the column"})
+    physical_quantity: Optional[str] = field(
+        default=None, metadata={"physical_quantity": "A description of the column"}
+    )
 
     yaml_representer = Header.yaml_representer_compact
 

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -621,6 +621,8 @@ class ValueVector(Header):
     unit: Optional[str] = field(default=None, metadata={"description": "SI unit string"})
     error: Optional[ErrorValue] = None
 
+    yaml_representer = Header.yaml_representer_compact
+
     def as_unit(self, output_unit):
         """
         Returns a (x, y, z) tuple of values as converted to the given unit.

--- a/orsopy/fileio/data_source.py
+++ b/orsopy/fileio/data_source.py
@@ -76,9 +76,18 @@ class Sample(Header):
 
 class Polarization(str, Enum):
     """
+    Polarization of the beam used for the reflectivity.
+
+    Neutrons:
     The first symbol indicates the magnetisation direction of the incident
-    beam. An optional second symbol indicates the direction of the scattered
-    beam, if a spin analyser is present.
+    beam, the second symbol indicates the direction of the scattered
+    beam. If either polarization or analysis are not employed the
+    symbol is replaced by "o".
+
+    X-rays:
+    Uses the conventional names pi, sigma, left and right. In experiments
+    with polarization analysis the incident and outgoing polarizations
+    are separated with an underscore "_".
     """
 
     unpolarized = "unpolarized"

--- a/orsopy/fileio/data_source.py
+++ b/orsopy/fileio/data_source.py
@@ -57,6 +57,7 @@ class Sample(Header):
         :code:`Si | SiO2 (20 angstrom) | Fe (200 angstrom) |
         air (beam side)`.
     :param description: Further details of the sample, e.g. size.
+    :param size: Sample size in x, y, z direction, where z is parallel to the surface normal.
     :param environment: Name of the sample environment device(s).
     :param sample_parameters: Dictionary of sample parameters.
     """
@@ -65,6 +66,7 @@ class Sample(Header):
     category: Optional[str] = None
     composition: Optional[str] = None
     description: Optional[str] = None
+    size: Optional[ValueVector] = None
     environment: Optional[List[str]] = None
     sample_parameters: Optional[Dict[str, Union[Value, ValueRange, ValueVector, ComplexValue]]] = field(
         default=None, metadata={"description": "Using keys for parameters and Value* objects for values."}

--- a/orsopy/fileio/data_source.py
+++ b/orsopy/fileio/data_source.py
@@ -57,7 +57,8 @@ class Sample(Header):
         :code:`Si | SiO2 (20 angstrom) | Fe (200 angstrom) |
         air (beam side)`.
     :param description: Further details of the sample, e.g. size.
-    :param size: Sample size in x, y, z direction, where z is parallel to the surface normal.
+    :param size: Sample size in x, y, z direction, where z is parallel to the surface normal
+        and x is along the beam direction (important for footprint correction).
     :param environment: Name of the sample environment device(s).
     :param sample_parameters: Dictionary of sample parameters.
     """

--- a/orsopy/fileio/data_source.py
+++ b/orsopy/fileio/data_source.py
@@ -92,6 +92,15 @@ class Polarization(str, Enum):
     mp = "mp"
     pm = "pm"
     pp = "pp"
+    # x-ray polarizations
+    pi = "pi"  # in scattering plane
+    sigma = "sigma"  # perpendicular to scattering plane
+    left = "left"  # circular left
+    right = "right"  # circular right
+    pi_pi = "pi_pi"
+    sigma_sigma = "sigma_sigma"
+    pi_sigma = "pi_sigma"
+    sigma_pi = "sigma_pi"
 
     def yaml_representer(self, dumper: yaml.Dumper):
         output = self.value

--- a/orsopy/fileio/schema/refl_header.schema.json
+++ b/orsopy/fileio/schema/refl_header.schema.json
@@ -168,6 +168,111 @@
         "probe"
       ]
     },
+    "ErrorValue": {
+      "title": "ErrorValue",
+      "type": "object",
+      "properties": {
+        "error_value": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "error_type": {
+          "enum": [
+            "uncertainty",
+            "resolution",
+            null
+          ],
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value_is": {
+          "enum": [
+            "sigma",
+            "FWHM",
+            null
+          ],
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "distribution": {
+          "enum": [
+            "gaussian",
+            "triangular",
+            "uniform",
+            "lorentzian",
+            null
+          ],
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "comment": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "error_value"
+      ]
+    },
+    "ValueVector": {
+      "title": "ValueVector",
+      "type": "object",
+      "properties": {
+        "x": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "y": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "z": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "unit": {
+          "description": "SI unit string",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "error": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ErrorValue"
+            }
+          ]
+        },
+        "comment": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
+    },
     "Value": {
       "title": "Value",
       "type": "object",
@@ -183,6 +288,13 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "error": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ErrorValue"
+            }
           ]
         },
         "comment": {
@@ -231,82 +343,20 @@
         "max"
       ]
     },
-    "ValueVector": {
-      "title": "ValueVector",
-      "type": "object",
-      "properties": {
-        "x": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "y": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "z": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "unit": {
-          "description": "SI unit string",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
-    },
     "ComplexValue": {
       "title": "ComplexValue",
       "type": "object",
       "properties": {
         "real": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "number"
-              }
-            },
-            {
-              "type": "null"
-            }
+          "type": [
+            "number",
+            "null"
           ]
         },
         "imag": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "type": "array",
-              "items": {
-                "type": "number"
-              }
-            },
-            {
-              "type": "null"
-            }
+          "type": [
+            "number",
+            "null"
           ]
         },
         "unit": {
@@ -314,6 +364,13 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "error": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ErrorValue"
+            }
           ]
         },
         "comment": {
@@ -353,6 +410,13 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "size": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ValueVector"
+            }
           ]
         },
         "environment": {
@@ -400,7 +464,7 @@
     },
     "Polarization": {
       "title": "Polarization",
-      "description": "The first symbol indicates the magnetisation direction of the incident\nbeam. An optional second symbol indicates the direction of the scattered\nbeam, if a spin analyser is present.",
+      "description": "Polarization of the beam used for the reflectivity.\n\nNeutrons:\nThe first symbol indicates the magnetisation direction of the incident\nbeam, the second symbol indicates the direction of the scattered\nbeam. If either polarization or analysis are not employed the\nsymbol is replaced by \"o\".\n\nX-rays:\nUses the conventional names pi, sigma, left and right. In experiments\nwith polarization analysis the incident and outgoing polarizations\nare separated with an underscore \"_\".",
       "enum": [
         "unpolarized",
         "po",
@@ -410,7 +474,15 @@
         "mm",
         "mp",
         "pm",
-        "pp"
+        "pp",
+        "pi",
+        "sigma",
+        "left",
+        "right",
+        "pi_pi",
+        "sigma_sigma",
+        "pi_sigma",
+        "sigma_pi"
       ],
       "type": "string"
     },
@@ -743,8 +815,8 @@
             "null"
           ]
         },
-        "dimension": {
-          "dimension": "A description of the column",
+        "physical_quantity": {
+          "physical_quantity": "A description of the column",
           "type": [
             "string",
             "null"
@@ -835,8 +907,8 @@
             null
           ]
         },
-        "dimension": {
-          "dimension": "dimension of column",
+        "physical_quantity": {
+          "physical_quantity": "physical quantity the column describes",
           "anyOf": [
             {
               "type": "string"
@@ -879,8 +951,8 @@
             null
           ]
         },
-        "dimension": {
-          "dimension": "dimension of column",
+        "physical_quantity": {
+          "physical_quantity": "physical quantity the column describes",
           "anyOf": [
             {
               "type": "string"

--- a/orsopy/fileio/schema/refl_header.schema.yaml
+++ b/orsopy/fileio/schema/refl_header.schema.yaml
@@ -7,12 +7,12 @@ definitions:
         type:
         - string
         - 'null'
-      dimension:
-        dimension: A description of the column
+      name:
         type:
         - string
         - 'null'
-      name:
+      physical_quantity:
+        physical_quantity: A description of the column
         type:
         - string
         - 'null'
@@ -31,20 +31,17 @@ definitions:
         type:
         - string
         - 'null'
+      error:
+        anyOf:
+        - $ref: '#/definitions/ErrorValue'
       imag:
-        anyOf:
-        - type: number
-        - items:
-            type: number
-          type: array
-        - type: 'null'
+        type:
+        - number
+        - 'null'
       real:
-        anyOf:
-        - type: number
-        - items:
-            type: number
-          type: array
-        - type: 'null'
+        type:
+        - number
+        - 'null'
       unit:
         description: SI unit string
         type:
@@ -118,6 +115,46 @@ definitions:
     required:
     - error_of
     title: ErrorColumn
+    type: object
+  ErrorValue:
+    properties:
+      comment:
+        type:
+        - string
+        - 'null'
+      distribution:
+        enum:
+        - gaussian
+        - triangular
+        - uniform
+        - lorentzian
+        - null
+        type:
+        - string
+        - 'null'
+      error_type:
+        enum:
+        - uncertainty
+        - resolution
+        - null
+        type:
+        - string
+        - 'null'
+      error_value:
+        type:
+        - number
+        - 'null'
+      value_is:
+        enum:
+        - sigma
+        - FWHM
+        - null
+        type:
+        - string
+        - 'null'
+    required:
+    - error_value
+    title: ErrorValue
     type: object
   Experiment:
     properties:
@@ -283,11 +320,27 @@ definitions:
     title: Person
     type: object
   Polarization:
-    description: 'The first symbol indicates the magnetisation direction of the incident
+    description: 'Polarization of the beam used for the reflectivity.
 
-      beam. An optional second symbol indicates the direction of the scattered
 
-      beam, if a spin analyser is present.'
+      Neutrons:
+
+      The first symbol indicates the magnetisation direction of the incident
+
+      beam, the second symbol indicates the direction of the scattered
+
+      beam. If either polarization or analysis are not employed the
+
+      symbol is replaced by "o".
+
+
+      X-rays:
+
+      Uses the conventional names pi, sigma, left and right. In experiments
+
+      with polarization analysis the incident and outgoing polarizations
+
+      are separated with an underscore "_".'
     enum:
     - unpolarized
     - po
@@ -298,6 +351,14 @@ definitions:
     - mp
     - pm
     - pp
+    - pi
+    - sigma
+    - left
+    - right
+    - pi_pi
+    - sigma_sigma
+    - pi_sigma
+    - sigma_pi
     title: Polarization
     type: string
   Qz_column:
@@ -306,14 +367,14 @@ definitions:
         anyOf:
         - type: string
         - type: 'null'
-      dimension:
-        anyOf:
-        - type: string
-        - type: 'null'
-        dimension: dimension of column
       name:
         enum:
         - Qz
+      physical_quantity:
+        anyOf:
+        - type: string
+        - type: 'null'
+        physical_quantity: physical quantity the column describes
       unit:
         enum:
         - 1/angstrom
@@ -331,14 +392,14 @@ definitions:
         anyOf:
         - type: string
         - type: 'null'
-      dimension:
-        anyOf:
-        - type: string
-        - type: 'null'
-        dimension: dimension of column
       name:
         enum:
         - R
+      physical_quantity:
+        anyOf:
+        - type: string
+        - type: 'null'
+        physical_quantity: physical quantity the column describes
       unit:
         enum:
         - 1/angstrom
@@ -437,6 +498,9 @@ definitions:
         type:
         - object
         - 'null'
+      size:
+        anyOf:
+        - $ref: '#/definitions/ValueVector'
     required:
     - name
     title: Sample
@@ -469,6 +533,9 @@ definitions:
         type:
         - string
         - 'null'
+      error:
+        anyOf:
+        - $ref: '#/definitions/ErrorValue'
       magnitude:
         type:
         - number
@@ -512,6 +579,9 @@ definitions:
         type:
         - string
         - 'null'
+      error:
+        anyOf:
+        - $ref: '#/definitions/ErrorValue'
       unit:
         description: SI unit string
         type:

--- a/tests/test_fileio/test_base.py
+++ b/tests/test_fileio/test_base.py
@@ -320,7 +320,7 @@ class TestColumn(unittest.TestCase):
         Creation of a column.
         """
         value = base.Column("q", "1/angstrom", "qz vector")
-        assert value.dimension == "qz vector"
+        assert value.physical_quantity == "qz vector"
         assert value.name == "q"
         assert value.unit == "1/angstrom"
 
@@ -336,7 +336,7 @@ class TestColumn(unittest.TestCase):
         Transformation to yaml.
         """
         value = base.Column("q", "1/angstrom", "qz vector")
-        assert value.to_yaml() == "{name: q, unit: 1/angstrom, dimension: qz vector}\n"
+        assert value.to_yaml() == "{name: q, unit: 1/angstrom, physical_quantity: qz vector}\n"
 
     def test_no_description_to_yaml(self):
         """

--- a/tests/test_fileio/test_base.py
+++ b/tests/test_fileio/test_base.py
@@ -234,14 +234,14 @@ class TestValueVector(unittest.TestCase):
         Transform to yaml.
         """
         value = base.ValueVector(1.0, 2.0, 3.0, "m")
-        assert value.to_yaml() == "x: 1.0\ny: 2.0\nz: 3.0\nunit: m\n"
+        assert value.to_yaml() == "{x: 1.0, y: 2.0, z: 3.0, unit: m}\n"
 
     def test_two_dimensional_to_yaml(self):
         """
         Transform to yaml with only two dimensions.
         """
         value = base.ValueVector(1.0, 2.0, None, "m")
-        assert value.to_yaml() == "x: 1.0\ny: 2.0\nz: null\nunit: m\n"
+        assert value.to_yaml() == "{x: 1.0, y: 2.0, z: null, unit: m}\n"
 
     def test_unit_conversion(self):
         value = base.ValueVector(1.0, 2.0, 3.0, "mm")

--- a/tests/test_fileio/test_data_source.py
+++ b/tests/test_fileio/test_data_source.py
@@ -96,7 +96,9 @@ class TestSample(unittest.TestCase):
         assert value.category is None
         assert value.composition is None
         assert value.description is None
+        assert value.size is None
         assert value.environment is None
+        assert value.sample_parameters is None
 
     def test_to_yaml(self):
         """
@@ -115,14 +117,16 @@ class TestSample(unittest.TestCase):
             composition="Si | SiO2(20 A) | Fe(200 A) | air(beam side)",
             description="The sample is without flaws",
             environment=["Temperature cell"],
-            sample_parameters={},
+            size=base.ValueVector(1.0, 2.0, 3.0, "mm"),
+            sample_parameters={"a": base.Value(13.4)},
         )
         assert value.name == "A Perfect Sample"
         assert value.category == "solid/gas"
         assert value.composition == "Si | SiO2(20 A) | " + "Fe(200 A) | air(beam side)"
         assert value.description == "The sample is without flaws"
+        assert value.size == base.ValueVector(1.0, 2.0, 3.0, "mm")
         assert value.environment == ["Temperature cell"]
-        assert value.sample_parameters == {}
+        assert value.sample_parameters == {"a": base.Value(13.4)}
 
     def test_to_yaml_optionals(self):
         """
@@ -134,13 +138,17 @@ class TestSample(unittest.TestCase):
             composition="Si | SiO2(20 A) | Fe(200 A) | air(beam side)",
             description="The sample is without flaws",
             environment=["Temperature cell"],
+            size=base.ValueVector(1.0, 2.0, 3.0, "mm"),
+            sample_parameters={"a": base.Value(13.4)},
         )
         assert (
             value.to_yaml()
             == "name: A Perfect Sample\ncategory: "
             + "solid/gas\ncomposition: Si | SiO2(20 A) | Fe(200 A) | air"
             + "(beam side)\ndescription: The sample is without flaws\n"
+            + "size: {x: 1.0, y: 2.0, z: 3.0, unit: mm}\n"
             + "environment:\n- Temperature cell\n"
+            + "sample_parameters:\n  a: {magnitude: 13.4}\n"
         )
 
 

--- a/tools/header_schema.py
+++ b/tools/header_schema.py
@@ -47,7 +47,10 @@ column_schema = {
     "properties": {
         "name": {"enum": ["<cname>"]},
         "unit": {"enum": ["1/angstrom", "1/nm", "1", "1/s", None]},
-        "dimension": {"dimension": "dimension of column", "anyOf": [{"type": "string"}, {"type": "null"}]},
+        "physical_quantity": {
+            "physical_quantity": "physical quantity the column describes",
+            "anyOf": [{"type": "string"}, {"type": "null"}],
+        },
         "comment": {"anyOf": [{"type": "string"}, {"type": "null"}]},
     },
     "required": ["name"],


### PR DESCRIPTION
I've implemented some additional optional attributes following the discussions at the general assembly and the anonymous feedback https://www.reflectometry.org/file_format/specs_discussion. As these only add new optional items I don't see an issue updating the spec to a new minor revision.

There is just one change that "breaks" the previous spec and that is the change of `Column.dimension` to `Column.physical_property`. For me this is an important correction of a mistake in the previous spec.