### PR TITLE
add optional content hash to File object

### DIFF
--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -725,6 +725,16 @@ class ErrorColumn(Header):
 
 
 @orsodataclass
+class ContentHash(Header):
+    """
+    A hash of some content, using standard algorithms
+    """
+
+    digest: str
+    algorithm: Literal["sha1", "sha256", "sha384", "sha512", "sha3_256", "sha3_512"]
+
+
+@orsodataclass
 class File(Header):
     """
     A file with file path and a last modified timestamp.
@@ -739,6 +749,7 @@ class File(Header):
             " itself"
         },
     )
+    hash: Optional[ContentHash] = None
 
     def __post_init__(self):
         """


### PR DESCRIPTION
In addition to timestamp, it would be nice for reproducibility if we could specify a hash of the file contents for File objects, which are used in the Measurement class.