### PR TITLE
Convert numpy scalars to native python objects before sending to yaml dump

### DIFF
--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -431,6 +431,9 @@ class OrsoDumper(yaml.SafeDumper):
         elif isinstance(data, datetime.datetime):
             value = data.isoformat("T")
             return super().represent_scalar("tag:yaml.org,2002:timestamp", value)
+        elif (not np.shape(data)) and hasattr(data, "item"):
+            # If data is a numpy scalar, convert to a python object
+            return super().represent_data(data.item())
         else:
             return super().represent_data(data)
 

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -431,7 +431,7 @@ class OrsoDumper(yaml.SafeDumper):
         elif isinstance(data, datetime.datetime):
             value = data.isoformat("T")
             return super().represent_scalar("tag:yaml.org,2002:timestamp", value)
-        elif (not np.shape(data)) and hasattr(data, "item"):
+        elif np.isscalar(data) and hasattr(data, "item"):
             # If data is a numpy scalar, convert to a python object
             return super().represent_data(data.item())
         else:

--- a/tests/test_fileio/test_orso.py
+++ b/tests/test_fileio/test_orso.py
@@ -230,6 +230,17 @@ class TestOrso(unittest.TestCase):
         info = datasets[0].info
         assert hasattr(info.data_source.measurement.instrument_settings.incident_angle, "resolution")
 
+    def test_save_numpy_scalar_dtypes(self):
+        info = fileio.Orso.empty()
+        info.data_source.measurement.instrument_settings.wavelength = Value(np.float64(10.0))
+        info.data_source.measurement.instrument_settings.incident_angle = Value(np.int32(2))
+        ds = fileio.orso.OrsoDataset(info, np.arange(20.).reshape(10, 2))
+        fileio.save_orso([ds], "test_numpy.ort")
+        ls = fileio.load_orso("test_numpy.ort")
+        i_s = ls[0].info.data_source.measurement.instrument_settings
+        assert i_s.wavelength == 10.0
+        assert i_s.incident_angle == 2
+
 
 class TestFunctions(unittest.TestCase):
     """

--- a/tests/test_fileio/test_orso.py
+++ b/tests/test_fileio/test_orso.py
@@ -238,8 +238,8 @@ class TestOrso(unittest.TestCase):
         fileio.save_orso([ds], "test_numpy.ort")
         ls = fileio.load_orso("test_numpy.ort")
         i_s = ls[0].info.data_source.measurement.instrument_settings
-        assert i_s.wavelength == 10.0
-        assert i_s.incident_angle == 2
+        assert i_s.wavelength.magnitude == 10.0
+        assert i_s.incident_angle.magnitude == 2
 
 
 class TestFunctions(unittest.TestCase):


### PR DESCRIPTION
This came up when trying to save values from Scipp variables to an Orso file.
In recent versions of Scipp, var.value() now returns numpy types, e.g. `np.float64` instead ofpython `float`.
We use the `item()` method to convert them to a python type before sending to yaml which cannot handle the numpy scalars.