### PR TITLE
Data order columns first

### DIFF
--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -801,7 +801,7 @@ def _read_header_data(file: Union[TextIO, str], validate: bool = False) -> Tuple
                 # numerical array  and start collecting the numbers for this
                 # dataset
                 _d = np.array([np.fromstring(v, dtype=float, sep=" ") for v in _ds_lines])
-                data.append(_d)
+                data.append(_d.T)
                 _ds_lines = []
 
                 # append '---' to signify the start of a new yaml document
@@ -814,7 +814,7 @@ def _read_header_data(file: Union[TextIO, str], validate: bool = False) -> Tuple
 
         # append the last numerical array
         _d = np.array([np.fromstring(v, dtype=float, sep=" ") for v in _ds_lines])
-        data.append(_d)
+        data.append(_d.T)
 
         yml = "".join(header)
 

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -163,11 +163,14 @@ class OrsoDataset:
     """
 
     info: Orso
-    data: Any
+    data: Union[np.ndarray, Sequence[np.ndarray], Sequence[Sequence]]
 
     def __post_init__(self):
-        if self.data.shape[1] != len(self.info.columns):
+        if len(self.data) != len(self.info.columns):
             raise ValueError("Data has to have the same number of columns as header")
+        column_lengths = set(len(c) for c in self.data)
+        if len(column_lengths) > 1:
+            raise ValueError("Columns must all have the same length in first dimension")
 
     def header(self) -> str:
         """
@@ -249,13 +252,13 @@ def save_orso(
 
         ds1 = datasets[0]
         header += ds1.header()
-        np.savetxt(f, ds1.data, header=header, fmt="%-22.16e")
+        np.savetxt(f, np.asarray(ds1.data).T, header=header, fmt="%-22.16e")
 
         for dsi in datasets[1:]:
             # write an optional spacer string between dataset e.g. \n
             f.write(data_separator)
             hi = ds1.diff_header(dsi)
-            np.savetxt(f, dsi.data, header=hi, fmt="%-22.16e")
+            np.savetxt(f, np.asarray(dsi.data).T, header=hi, fmt="%-22.16e")
 
 
 def load_orso(fname: Union[TextIO, str]) -> List[OrsoDataset]:

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -3,7 +3,7 @@ Implementation of the top level class for the ORSO header.
 """
 
 from dataclasses import dataclass
-from typing import Any, List, Optional, TextIO, Union
+from typing import Any, List, Optional, Sequence, TextIO, Union
 
 import numpy as np
 import yaml

--- a/orsopy/fileio/tests/test_orso.py
+++ b/orsopy/fileio/tests/test_orso.py
@@ -107,8 +107,8 @@ class TestOrso(unittest.TestCase):
         # test write and read of multiple datasets
         info = fileio.Orso.empty()
         info2 = fileio.Orso.empty()
-        data = np.zeros((100, 3))
-        data[:] = np.arange(100.0)[:, None]
+        data = np.zeros((3, 100))
+        data[:] = np.arange(100.0)[None, :]
 
         info.columns = [
             fileio.Column("Qz", "1/angstrom"),
@@ -180,14 +180,14 @@ class TestOrso(unittest.TestCase):
         info2.data_set = 0
         info2.columns = [Column("stuff")] * 4
 
-        ds = OrsoDataset(info, np.empty((2, 4)))
-        ds2 = OrsoDataset(info2, np.empty((2, 4)))
+        ds = OrsoDataset(info, np.empty((4, 2)))
+        ds2 = OrsoDataset(info2, np.empty((4, 2)))
 
         with pytest.raises(ValueError):
             fileio.save_orso([ds, ds2], "test_data_set.ort")
 
         with pytest.raises(ValueError):
-            OrsoDataset(info, np.empty((2, 5)))
+            OrsoDataset(info, np.empty((5, 2)))
 
     def test_user_data(self):
         # test write and read of userdata
@@ -198,8 +198,8 @@ class TestOrso(unittest.TestCase):
             fileio.ErrorColumn("R"),
         ]
 
-        data = np.zeros((100, 3))
-        data[:] = np.arange(100.0)[:, None]
+        data = np.zeros((3, 100))
+        data[:] = np.arange(100.0)[None, :]
         dct = {"ci": "1", "foo": ["bar", 1, 2, 3.5]}
         info.user_data = dct
         ds = fileio.OrsoDataset(info, data)
@@ -237,7 +237,7 @@ class TestOrso(unittest.TestCase):
         info = fileio.Orso.empty()
         info.data_source.measurement.instrument_settings.wavelength = Value(np.float64(10.0))
         info.data_source.measurement.instrument_settings.incident_angle = Value(np.int32(2))
-        ds = fileio.orso.OrsoDataset(info, np.arange(20.).reshape(10, 2))
+        ds = fileio.orso.OrsoDataset(info, np.arange(20.).reshape(2, 10))
         fileio.save_orso([ds], "test_numpy.ort")
         ls = fileio.load_orso("test_numpy.ort")
         i_s = ls[0].info.data_source.measurement.instrument_settings

--- a/orsopy/fileio/tests/test_schema.py
+++ b/orsopy/fileio/tests/test_schema.py
@@ -18,7 +18,7 @@ class TestSchema:
             schema = json.load(f)
 
         dct_list, data, version = _read_header_data(pth / "test_example.ort", validate=True)
-        assert data[0].shape == (2, 4)
+        assert data[0].shape == (4, 2)
         assert version == "0.1"
 
         # d contains datetime.datetime objects, which would fail the
@@ -34,4 +34,4 @@ class TestSchema:
         assert len(dct_list) == 2
         assert dct_list[1]["data_set"] == "spin_down"
         assert data[1].shape == (4, 4)
-        np.testing.assert_allclose(data[1][2:], data[0])
+        np.testing.assert_allclose(data[1][:, 2:], data[0])


### PR DESCRIPTION
As we consider support for multidimensional columns (e.g. resolution) it would make the most sense to have the column index first in the data order.  Then extra dimensions can be added to the shape.  

Under the current ordering, the length of the column is the first index, and the column number is the second index, and then additional dimensions would have to go after the column index, which is awkward.

Note that multidimensional columns will be most easily supported in a binary format (NeXus).