### PR TITLE
adding self-build of docs (publishes to gh-pages branch)

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -2,8 +2,8 @@ name: Sphinx docs to gh-pages
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
 
   workflow_dispatch:        # Un comment line if you also want to trigger action manually
 

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -1,0 +1,37 @@
+name: Sphinx docs to gh-pages
+
+on:
+  push:
+    branches:
+      - main
+
+  workflow_dispatch:        # Un comment line if you also want to trigger action manually
+
+jobs:
+  sphinx_docs_to_gh-pages:
+    runs-on: ubuntu-latest
+    name: Sphinx docs to gh-pages
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Make conda environment
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: "3.10"    # Python version to build the html sphinx documentation
+          environment-file: docs_env.yaml    # Path to the documentation conda environment
+          auto-update-conda: false
+          auto-activate-base: false
+          show-channel-urls: true
+      - name: Installing the library
+        shell: bash -l {0}
+        run: |
+          python setup.py install
+      - name: Running the Sphinx to gh-pages Action
+        uses: uibcdf/action-sphinx-docs-to-gh-pages@v2.1.0
+        with:
+          branch: main
+          dir_docs: docs
+          sphinx-apidoc-opts: '--separate -o . ../'
+          sphinx-apidoc-exclude: '../*setup* ../*.ipynb'
+          sphinx-opts: ''

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,6 +4,9 @@ on:
   - push
   - pull_request
 
+  # Allows you to run this workflow manually from the Actions tab
+  - workflow_dispatch
+
 jobs:
   build:
 

--- a/README.rst
+++ b/README.rst
@@ -35,4 +35,4 @@ Features
 .. _`Documents`: https://orsopy.readthedocs.io/en/latest/documents.html
 .. _`contribute`: https://orsopy.readthedocs.io/en/latest/contributing.html
 .. _`ORSO Slack`: https://join.slack.com/t/orso-co/shared_invite/zt-z7p3v89g-~JgCbzcxurQP6ufqdfTCfw
-.. _`Reading and writing of ORSO specification reduced reflectivity files`: https://orsopy.rtfd.io/en/latest/modules.html#fileio
+.. _`Reading and writing of ORSO specification reduced reflectivity files`: modules.html#fileio

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'orsopy'
-copyright = "2021, ORSO"
+copyright = "2024, ORSO"
 author = "ORSO"
 
 # The version info for the project you're documenting, acts as replacement

--- a/docs_env.yaml
+++ b/docs_env.yaml
@@ -10,6 +10,11 @@ dependencies:
   # Write here all dependencies to compile the sphinx documentation.
   # This list is just an example
   - python=3.10
+  - numpy
+  - pint
+  - pytest
+  - h5py
+  - typing_extensions
   - sphinx
   - sphinx_rtd_theme
   - sphinxcontrib-bibtex

--- a/docs_env.yaml
+++ b/docs_env.yaml
@@ -1,0 +1,19 @@
+name: docs
+
+channels:
+
+  - conda-forge
+  - defaults
+
+dependencies:
+
+  # Write here all dependencies to compile the sphinx documentation.
+  # This list is just an example
+  - python=3.10
+  - sphinx
+  - sphinx_rtd_theme
+  - sphinxcontrib-bibtex
+  - sphinx-autodoc-typehints
+  - nbsphinx
+  - recommonmark
+  - sphinx-markdown-tables


### PR DESCRIPTION
We can build the docs ourselves instead of using readthedocs, which is an external point of failure. 

This will make it easier to maintain and debug the documentation build (all code owners have access)