### PR TITLE
Generate schema with pydantic v2

### DIFF
--- a/orsopy/__init__.py
+++ b/orsopy/__init__.py
@@ -1,6 +1,3 @@
 """Top-level package for orsopy."""
 
 __version__ = "1.2.0"
-
-# this is imported in submodules to be able to overwrite it with pydantic
-from dataclasses import dataclass

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -26,9 +26,7 @@ try:
 except ImportError:
     from .typing_backport import Literal, get_args, get_origin
 
-from dataclasses import MISSING, field, fields
-
-from .. import dataclass
+from dataclasses import MISSING, dataclass, field, fields
 
 
 def _noop(self, *args, **kw):

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -2,6 +2,7 @@
 Implementation of the base classes for the ORSO header.
 """
 
+import sys
 import datetime
 import json
 import os.path
@@ -969,6 +970,13 @@ def _validate_header_data(dct_list: List[dict]):
         :code:`'sQz'` are not the same.
     """
     import jsonschema
+
+    vi = sys.version_info
+    if vi.minor < 7:
+        warnings.warn(
+            ORSOSchemaWarning,
+            "Validation not possible with Python 3.6 with 2020-12 json schema"
+        )
 
     pth = os.path.dirname(__file__)
     schema_pth = os.path.join(pth, "schema", "refl_header.schema.json")

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -974,8 +974,8 @@ def _validate_header_data(dct_list: List[dict]):
     vi = sys.version_info
     if vi.minor < 7:
         warnings.warn(
-            ORSOSchemaWarning,
-            "Validation not possible with Python 3.6 with 2020-12 json schema"
+            "Validation not possible with Python 3.6 with 2020-12 json schema",
+            ORSOSchemaWarning
         )
 
     pth = os.path.dirname(__file__)

--- a/orsopy/fileio/data_source.py
+++ b/orsopy/fileio/data_source.py
@@ -1,14 +1,13 @@
 """
 Implementation of the data_source for the ORSO header.
 """
-from dataclasses import field
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Optional, Union
 
 import yaml
 
-from .. import dataclass
 from .base import AlternatingField, ComplexValue, File, Header, Person, Value, ValueRange, ValueVector
 from .model_language import SampleModel
 

--- a/orsopy/fileio/model_language.py
+++ b/orsopy/fileio/model_language.py
@@ -6,10 +6,9 @@ resolving the model to a simple list of slabs.
 """
 import warnings
 
-from dataclasses import field
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Union
 
-from .. import dataclass
 from ..utils.chemical_formula import Formula
 from ..utils.density_resolver import DensityResolver
 from .base import ComplexValue, Header, Value

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -2,12 +2,12 @@
 Implementation of the top level class for the ORSO header.
 """
 
+from dataclasses import dataclass
 from typing import BinaryIO, List, Optional, Sequence, TextIO, Union
 
 import numpy as np
 import yaml
 
-from .. import dataclass
 from .base import (JSON_MIMETYPE, Column, ErrorColumn, Header, OrsoDumper, _dict_diff, _nested_update,
                    _possibly_open_file, _read_header_data)
 from .data_source import DataSource

--- a/orsopy/fileio/reduction.py
+++ b/orsopy/fileio/reduction.py
@@ -4,10 +4,9 @@ The reduction elements for the ORSO header
 
 import datetime
 
-from dataclasses import field
+from dataclasses import dataclass, field
 from typing import List, Optional, Union
 
-from .. import dataclass
 from .base import Header, Person
 
 

--- a/orsopy/fileio/schema/refl_header.schema.json
+++ b/orsopy/fileio/schema/refl_header.schema.json
@@ -1,591 +1,49 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/reflectivity/orsopy/v1.2.0/orsopy/fileio/schema/refl_header.schema.json",
-  "title": "Orso",
-  "type": "object",
-  "properties": {
-    "data_source": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/DataSource"
-        }
-      ]
-    },
-    "reduction": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Reduction"
-        }
-      ]
-    },
-    "columns": {
-      "items": [
-        {
-          "$ref": "#/definitions/Qz_column"
-        },
-        {
-          "$ref": "#/definitions/R_column"
-        },
-        {
-          "$ref": "#/definitions/sR_column"
-        },
-        {
-          "$ref": "#/definitions/sQz_column"
-        }
-      ],
-      "type": [
-        "array",
-        "null"
-      ],
-      "additionalItems": {
-        "$ref": "#/definitions/Column"
-      }
-    },
-    "data_set": {
-      "anyOf": [
-        {
-          "type": "integer"
-        },
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "comment": {
-      "type": [
-        "string",
-        "null"
-      ]
-    }
-  },
-  "required": [
-    "data_source",
-    "reduction",
-    "columns"
-  ],
-  "definitions": {
-    "Person": {
-      "title": "Person",
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "affiliation": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "contact": {
-          "description": "Contact (email) address",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "name",
-        "affiliation"
-      ]
-    },
-    "Experiment": {
-      "title": "Experiment",
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "instrument": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "start_date": {
-          "format": "date-time",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "probe": {
-          "enum": [
-            "neutron",
-            "x-ray",
-            null
-          ],
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "facility": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "proposalID": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "doi": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "title",
-        "instrument",
-        "start_date",
-        "probe"
-      ]
-    },
-    "ErrorValue": {
-      "title": "ErrorValue",
-      "type": "object",
-      "properties": {
-        "error_value": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "error_type": {
-          "enum": [
-            "uncertainty",
-            "resolution",
-            null
-          ],
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "value_is": {
-          "enum": [
-            "sigma",
-            "FWHM",
-            null
-          ],
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "distribution": {
-          "enum": [
-            "gaussian",
-            "triangular",
-            "uniform",
-            "lorentzian",
-            null
-          ],
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "error_value"
-      ]
-    },
-    "ValueVector": {
-      "title": "ValueVector",
-      "type": "object",
-      "properties": {
-        "x": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "y": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "z": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "unit": {
-          "description": "SI unit string",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "error": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ErrorValue"
-            }
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
-    },
-    "Value": {
-      "title": "Value",
-      "type": "object",
-      "properties": {
-        "magnitude": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "unit": {
-          "description": "SI unit string",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "error": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ErrorValue"
-            }
-          ]
-        },
-        "offset": {
-          "description": "The offset applied to a value (e.g. motor) to retrieve the reported (corrected) magnitude",
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "magnitude"
-      ]
-    },
-    "ValueRange": {
-      "title": "ValueRange",
-      "type": "object",
-      "properties": {
-        "min": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "max": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "unit": {
-          "description": "SI unit string",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "individual_magnitudes": {
-          "description": "Can list each individual value that was present during the experiment, only for information.",
-          "items": {
-            "type": "number"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "offset": {
-          "description": "The offset applied to a value (e.g. motor) to retrieve the reported (corrected) min/max",
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "min",
-        "max"
-      ]
-    },
-    "ComplexValue": {
-      "title": "ComplexValue",
-      "type": "object",
-      "properties": {
-        "real": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "imag": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "unit": {
-          "description": "SI unit string",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "error": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ErrorValue"
-            }
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "real"
-      ]
-    },
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/reflectivity/orsopy/v1.1/orsopy/fileio/schema/refl_header.schema.json",
+  "$defs": {
     "AlternatingField": {
-      "title": "AlternatingField",
-      "type": "object",
       "properties": {
         "amplitude": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Value"
-            }
-          ]
+          "$ref": "#/$defs/Value"
         },
         "frequency": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Value"
-            }
-          ]
+          "$ref": "#/$defs/Value"
         },
         "phase": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Value"
+              "$ref": "#/$defs/Value"
+            },
+            {
+              "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
         "amplitude",
         "frequency"
-      ]
+      ],
+      "title": "AlternatingField",
+      "type": "object"
     },
-    "Material": {
-      "title": "Material",
-      "type": "object",
+    "Column": {
       "properties": {
-        "formula": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "mass_density": {
+        "name": {
           "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/Value"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "number_density": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/Value"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "sld": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ComplexValue"
-            },
-            {
-              "$ref": "#/definitions/Value"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "magnetic_moment": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/Value"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "relative_density": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      }
-    },
-    "Composit": {
-      "title": "Composit",
-      "type": "object",
-      "properties": {
-        "composition": {
-          "additionalProperties": {
-            "type": "number"
-          },
-          "type": [
-            "object",
-            "null"
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "composition"
-      ]
-    },
-    "Layer": {
-      "title": "Layer",
-      "type": "object",
-      "properties": {
-        "thickness": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/Value"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "roughness": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/Value"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "material": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Material"
-            },
-            {
-              "$ref": "#/definitions/Composit"
-            },
             {
               "type": "string"
             },
@@ -594,296 +52,952 @@
             }
           ]
         },
-        "composition": {
-          "additionalProperties": {
-            "type": "number"
-          },
-          "type": [
-            "object",
-            "null"
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      }
-    },
-    "SubStack": {
-      "title": "SubStack",
-      "type": "object",
-      "properties": {
-        "repetitions": {
-          "default": 1,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
-        "stack": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "sequence": {
-          "items": {
-            "$ref": "#/definitions/Layer"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "represents": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "arguments": {
-          "items": {},
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "keywords": {
-          "type": [
-            "object",
-            "null"
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      }
-    },
-    "ModelParameters": {
-      "title": "ModelParameters",
-      "type": "object",
-      "properties": {
-        "roughness": {
+        "unit": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Value"
+              "type": "string"
+            },
+            {
+              "type": "null"
             }
-          ]
+          ],
+          "default": null,
+          "description": "SI unit string"
         },
-        "length_unit": {
-          "default": "nm",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "mass_density_unit": {
-          "default": "g/cm^3",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "number_density_unit": {
-          "default": "1/nm^3",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "sld_unit": {
-          "default": "1/angstrom^2",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "magnetic_moment_unit": {
-          "default": "muB",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      }
-    },
-    "SampleModel": {
-      "title": "SampleModel",
-      "type": "object",
-      "properties": {
-        "stack": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "origin": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "sub_stacks": {
-          "additionalProperties": {
-            "$ref": "#/definitions/SubStack"
-          },
-          "type": [
-            "object",
-            "null"
-          ]
-        },
-        "layers": {
-          "additionalProperties": {
-            "$ref": "#/definitions/Layer"
-          },
-          "type": [
-            "object",
-            "null"
-          ]
-        },
-        "materials": {
-          "additionalProperties": {
-            "$ref": "#/definitions/Material"
-          },
-          "type": [
-            "object",
-            "null"
-          ]
-        },
-        "composits": {
-          "additionalProperties": {
-            "$ref": "#/definitions/Composit"
-          },
-          "type": [
-            "object",
-            "null"
-          ]
-        },
-        "globals": {
+        "physical_quantity": {
           "anyOf": [
             {
-              "$ref": "#/definitions/ModelParameters"
+              "type": "string"
+            },
+            {
+              "type": "null"
             }
-          ]
+          ],
+          "default": null,
+          "description": "A description of the physical meaning for this column. For quantities defined by ORSO in header metadata the same name should be used.(For example 'wavelength' or 'incident_angle' to indicate a column specifying those quantities on a point-by-point basis.)For canonical names of physical quantities see https://www.reflectometry.org/file_format/specification."
         },
-        "reference": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "stack"
-      ]
-    },
-    "Sample": {
-      "title": "Sample",
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "category": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "composition": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "description": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "size": {
+        "flag_is": {
           "anyOf": [
             {
-              "$ref": "#/definitions/ValueVector"
-            }
-          ]
-        },
-        "environment": {
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "sample_parameters": {
-          "description": "Using keys for parameters and Value* objects for values.",
-          "additionalProperties": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Value"
+              "items": {
+                "type": "string"
               },
-              {
-                "$ref": "#/definitions/ValueRange"
-              },
-              {
-                "$ref": "#/definitions/ValueVector"
-              },
-              {
-                "$ref": "#/definitions/ComplexValue"
-              },
-              {
-                "$ref": "#/definitions/AlternatingField"
-              }
-            ]
-          },
-          "type": [
-            "object",
-            "null"
-          ]
-        },
-        "model": {
-          "anyOf": [
+              "type": "array"
+            },
             {
-              "$ref": "#/definitions/SampleModel"
+              "type": "null"
             }
-          ]
+          ],
+          "default": null,
+          "description": "A list of items that a flag-value in this column stands for."
         },
         "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
         "name"
-      ]
+      ],
+      "title": "Column",
+      "type": "object"
+    },
+    "ComplexValue": {
+      "properties": {
+        "real": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "imag": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "SI unit string"
+        },
+        "error": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ErrorValue"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "real"
+      ],
+      "title": "ComplexValue",
+      "type": "object"
+    },
+    "Composit": {
+      "properties": {
+        "composition": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "composition"
+      ],
+      "title": "Composit",
+      "type": "object"
+    },
+    "DataSource": {
+      "properties": {
+        "owner": {
+          "$ref": "#/$defs/Person"
+        },
+        "experiment": {
+          "$ref": "#/$defs/Experiment"
+        },
+        "sample": {
+          "$ref": "#/$defs/Sample"
+        },
+        "measurement": {
+          "$ref": "#/$defs/Measurement"
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "owner",
+        "experiment",
+        "sample",
+        "measurement"
+      ],
+      "title": "DataSource",
+      "type": "object"
+    },
+    "ErrorColumn": {
+      "properties": {
+        "error_of": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "error_type": {
+          "anyOf": [
+            {
+              "enum": [
+                "uncertainty",
+                "resolution"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "value_is": {
+          "anyOf": [
+            {
+              "enum": [
+                "sigma",
+                "FWHM"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "distribution": {
+          "anyOf": [
+            {
+              "enum": [
+                "gaussian",
+                "triangular",
+                "uniform",
+                "lorentzian"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "error_of"
+      ],
+      "title": "ErrorColumn",
+      "type": "object"
+    },
+    "ErrorValue": {
+      "properties": {
+        "error_value": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "error_type": {
+          "anyOf": [
+            {
+              "enum": [
+                "uncertainty",
+                "resolution"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "value_is": {
+          "anyOf": [
+            {
+              "enum": [
+                "sigma",
+                "FWHM"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "distribution": {
+          "anyOf": [
+            {
+              "enum": [
+                "gaussian",
+                "triangular",
+                "uniform",
+                "lorentzian"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "error_value"
+      ],
+      "title": "ErrorValue",
+      "type": "object"
+    },
+    "Experiment": {
+      "properties": {
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "instrument": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "start_date": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "format": "date-time"
+        },
+        "probe": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "enum": [
+            "neutron",
+            "x-ray",
+            null
+          ]
+        },
+        "facility": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "proposalID": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "doi": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "title",
+        "instrument",
+        "start_date",
+        "probe"
+      ],
+      "title": "Experiment",
+      "type": "object"
+    },
+    "File": {
+      "properties": {
+        "file": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "timestamp": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Last modified timestamp. If it's not specified, then an attempt will be made to check on the file itself"
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "file"
+      ],
+      "title": "File",
+      "type": "object"
+    },
+    "InstrumentSettings": {
+      "properties": {
+        "incident_angle": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Value"
+            },
+            {
+              "$ref": "#/$defs/ValueRange"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "wavelength": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Value"
+            },
+            {
+              "$ref": "#/$defs/ValueRange"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "polarization": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Polarization"
+            },
+            {
+              "$ref": "#/$defs/ValueVector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "unpolarized",
+          "description": "Polarization described as unpolarized/ po/ mo / op / om / pp / pm / mp / mm / vector"
+        },
+        "configuration": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "half / full polarized | liquid_surface | etc"
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "incident_angle",
+        "wavelength"
+      ],
+      "title": "InstrumentSettings",
+      "type": "object"
+    },
+    "Layer": {
+      "properties": {
+        "thickness": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/$defs/Value"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "roughness": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/$defs/Value"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "material": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Material"
+            },
+            {
+              "$ref": "#/$defs/Composit"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "composition": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "number"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "Layer",
+      "type": "object"
+    },
+    "Material": {
+      "properties": {
+        "formula": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "mass_density": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/$defs/Value"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "number_density": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/$defs/Value"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "sld": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/$defs/ComplexValue"
+            },
+            {
+              "$ref": "#/$defs/Value"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "magnetic_moment": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/$defs/Value"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "relative_density": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "Material",
+      "type": "object"
+    },
+    "Measurement": {
+      "properties": {
+        "instrument_settings": {
+          "$ref": "#/$defs/InstrumentSettings"
+        },
+        "data_files": {
+          "anyOf": [
+            {
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/File"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "additional_files": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/File"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "scheme": {
+          "anyOf": [
+            {
+              "enum": [
+                "angle- and energy-dispersive",
+                "angle-dispersive",
+                "energy-dispersive"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "instrument_settings",
+        "data_files"
+      ],
+      "title": "Measurement",
+      "type": "object"
+    },
+    "ModelParameters": {
+      "properties": {
+        "roughness": {
+          "$ref": "#/$defs/Value"
+        },
+        "length_unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "nm"
+        },
+        "mass_density_unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "g/cm^3"
+        },
+        "number_density_unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "1/nm^3"
+        },
+        "sld_unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "1/angstrom^2"
+        },
+        "magnetic_moment_unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": "muB"
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "ModelParameters",
+      "type": "object"
+    },
+    "Person": {
+      "properties": {
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "affiliation": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "contact": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Contact (email) address"
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "name",
+        "affiliation"
+      ],
+      "title": "Person",
+      "type": "object"
     },
     "Polarization": {
-      "title": "Polarization",
       "description": "Polarization of the beam used for the reflectivity.\n\nNeutrons:\nThe first symbol indicates the magnetisation direction of the incident\nbeam, the second symbol indicates the direction of the scattered\nbeam. If either polarization or analysis are not employed the\nsymbol is replaced by \"o\".\n\nX-rays:\nUses the conventional names pi, sigma, left and right. In experiments\nwith polarization analysis the incident and outgoing polarizations\nare separated with an underscore \"_\".",
       "enum": [
         "unpolarized",
@@ -904,425 +1018,727 @@
         "pi_sigma",
         "sigma_pi"
       ],
+      "title": "Polarization",
       "type": "string"
     },
-    "InstrumentSettings": {
-      "title": "InstrumentSettings",
-      "type": "object",
-      "properties": {
-        "incident_angle": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Value"
-            },
-            {
-              "$ref": "#/definitions/ValueRange"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "wavelength": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Value"
-            },
-            {
-              "$ref": "#/definitions/ValueRange"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "polarization": {
-          "description": "Polarization described as unpolarized/ po/ mo / op / om / pp / pm / mp / mm / vector",
-          "default": "unpolarized",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Polarization"
-            },
-            {
-              "$ref": "#/definitions/ValueVector"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "configuration": {
-          "description": "half / full polarized | liquid_surface | etc",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "incident_angle",
-        "wavelength"
-      ]
-    },
-    "File": {
-      "title": "File",
-      "type": "object",
-      "properties": {
-        "file": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "timestamp": {
-          "description": "Last modified timestamp. If it's not specified, then an attempt will be made to check on the file itself",
-          "format": "date-time",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "file"
-      ]
-    },
-    "Measurement": {
-      "title": "Measurement",
-      "type": "object",
-      "properties": {
-        "instrument_settings": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/InstrumentSettings"
-            }
-          ]
-        },
-        "data_files": {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/File"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "additional_files": {
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/File"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "scheme": {
-          "enum": [
-            "angle- and energy-dispersive",
-            "angle-dispersive",
-            "energy-dispersive",
-            null
-          ],
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "instrument_settings",
-        "data_files"
-      ]
-    },
-    "DataSource": {
-      "title": "DataSource",
-      "type": "object",
-      "properties": {
-        "owner": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Person"
-            }
-          ]
-        },
-        "experiment": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Experiment"
-            }
-          ]
-        },
-        "sample": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Sample"
-            }
-          ]
-        },
-        "measurement": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Measurement"
-            }
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "owner",
-        "experiment",
-        "sample",
-        "measurement"
-      ]
-    },
-    "Software": {
-      "title": "Software",
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "version": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "platform": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "name"
-      ]
-    },
     "Reduction": {
-      "title": "Reduction",
-      "type": "object",
       "properties": {
         "software": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Software"
-            }
-          ]
+          "$ref": "#/$defs/Software"
         },
         "timestamp": {
-          "description": "Timestamp string, formatted as ISO 8601 datetime",
-          "format": "date-time",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Timestamp string, formatted as ISO 8601 datetime"
         },
         "creator": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Person"
+              "$ref": "#/$defs/Person"
+            },
+            {
+              "type": "null"
             }
-          ]
+          ],
+          "default": null
         },
         "corrections": {
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "computer": {
-          "description": "Computer used for reduction",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Computer used for reduction"
         },
         "call": {
-          "description": "The command line call used",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The command line call used"
         },
         "script": {
-          "description": "Path to reduction script or notebook",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Path to reduction script or notebook"
         },
         "binary": {
-          "description": "Path to full information file",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Path to full information file"
         },
         "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
         "software"
-      ]
+      ],
+      "title": "Reduction",
+      "type": "object"
     },
-    "Column": {
-      "title": "Column",
-      "type": "object",
+    "Sample": {
       "properties": {
         "name": {
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
-        "unit": {
-          "description": "SI unit string",
-          "type": [
-            "string",
-            "null"
-          ]
+        "category": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
-        "physical_quantity": {
-          "description": "A description of the physical meaning for this column. For quantities defined by ORSO in header metadata the same name should be used.(For example 'wavelength' or 'incident_angle' to indicate a column specifying those quantities on a point-by-point basis.)For canonical names of physical quantities see https://www.reflectometry.org/file_format/specification.",
-          "type": [
-            "string",
-            "null"
-          ]
+        "composition": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
-        "flag_is": {
-          "description": "A list of items that a flag-value in this column stands for.",
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "size": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ValueVector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "environment": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "sample_parameters": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Value"
+                  },
+                  {
+                    "$ref": "#/$defs/ValueRange"
+                  },
+                  {
+                    "$ref": "#/$defs/ValueVector"
+                  },
+                  {
+                    "$ref": "#/$defs/ComplexValue"
+                  },
+                  {
+                    "$ref": "#/$defs/AlternatingField"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Using keys for parameters and Value* objects for values."
+        },
+        "model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SampleModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
         "name"
-      ]
+      ],
+      "title": "Sample",
+      "type": "object"
     },
-    "ErrorColumn": {
-      "title": "ErrorColumn",
-      "type": "object",
+    "SampleModel": {
       "properties": {
-        "error_of": {
-          "type": [
-            "string",
-            "null"
+        "stack": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
-        "error_type": {
-          "enum": [
-            "uncertainty",
-            "resolution",
-            null
+        "origin": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
           ],
-          "type": [
-            "string",
-            "null"
-          ]
+          "default": null
         },
-        "value_is": {
-          "enum": [
-            "sigma",
-            "FWHM",
-            null
+        "sub_stacks": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/SubStack"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
           ],
-          "type": [
-            "string",
-            "null"
-          ]
+          "default": null
         },
-        "distribution": {
-          "enum": [
-            "gaussian",
-            "triangular",
-            "uniform",
-            "lorentzian",
-            null
+        "layers": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/Layer"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
           ],
-          "type": [
-            "string",
-            "null"
-          ]
+          "default": null
+        },
+        "materials": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/Material"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "composits": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "$ref": "#/$defs/Composit"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "globals": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModelParameters"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "reference": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         },
         "comment": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       },
       "required": [
-        "error_of"
-      ]
+        "stack"
+      ],
+      "title": "SampleModel",
+      "type": "object"
+    },
+    "Software": {
+      "properties": {
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "version": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "platform": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Software",
+      "type": "object"
+    },
+    "SubStack": {
+      "properties": {
+        "repetitions": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 1
+        },
+        "stack": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "sequence": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Layer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "represents": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "arguments": {
+          "anyOf": [
+            {
+              "items": {},
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "keywords": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "title": "SubStack",
+      "type": "object"
+    },
+    "Value": {
+      "properties": {
+        "magnitude": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "SI unit string"
+        },
+        "error": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ErrorValue"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The offset applied to a value (e.g. motor) to retrieve the reported (corrected) magnitude"
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "magnitude"
+      ],
+      "title": "Value",
+      "type": "object"
+    },
+    "ValueRange": {
+      "properties": {
+        "min": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "max": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "SI unit string"
+        },
+        "individual_magnitudes": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Can list each individual value that was present during the experiment, only for information."
+        },
+        "offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The offset applied to a value (e.g. motor) to retrieve the reported (corrected) min/max"
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "min",
+        "max"
+      ],
+      "title": "ValueRange",
+      "type": "object"
+    },
+    "ValueVector": {
+      "properties": {
+        "x": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "y": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "z": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "unit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "SI unit string"
+        },
+        "error": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ErrorValue"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "comment": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
+      "title": "ValueVector",
+      "type": "object"
     },
     "Qz_column": {
-      "title": "Qz",
-      "type": "object",
       "properties": {
         "name": {
           "enum": [
@@ -1331,15 +1747,14 @@
         },
         "unit": {
           "enum": [
-            "1/angstrom",
+            null,
             "1/nm",
+            "1/angstrom",
             "1",
-            "1/s",
-            null
+            "1/s"
           ]
         },
         "physical_quantity": {
-          "physical_quantity": "physical quantity the column describes",
           "anyOf": [
             {
               "type": "string"
@@ -1347,7 +1762,26 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null,
+          "description": "A description of the physical meaning for this column. For quantities defined by ORSO in header metadata the same name should be used.(For example 'wavelength' or 'incident_angle' to indicate a column specifying those quantities on a point-by-point basis.)For canonical names of physical quantities see https://www.reflectometry.org/file_format/specification.",
+          "title": "Physical Quantity"
+        },
+        "flag_is": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A list of items that a flag-value in this column stands for.",
+          "title": "Flag Is"
         },
         "comment": {
           "anyOf": [
@@ -1357,16 +1791,18 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null,
+          "title": "Comment"
         }
       },
       "required": [
         "name"
-      ]
+      ],
+      "title": "Qz",
+      "type": "object"
     },
     "R_column": {
-      "title": "R",
-      "type": "object",
       "properties": {
         "name": {
           "enum": [
@@ -1375,15 +1811,14 @@
         },
         "unit": {
           "enum": [
-            "1/angstrom",
+            null,
             "1/nm",
+            "1/angstrom",
             "1",
-            "1/s",
-            null
+            "1/s"
           ]
         },
         "physical_quantity": {
-          "physical_quantity": "physical quantity the column describes",
           "anyOf": [
             {
               "type": "string"
@@ -1391,7 +1826,26 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null,
+          "description": "A description of the physical meaning for this column. For quantities defined by ORSO in header metadata the same name should be used.(For example 'wavelength' or 'incident_angle' to indicate a column specifying those quantities on a point-by-point basis.)For canonical names of physical quantities see https://www.reflectometry.org/file_format/specification.",
+          "title": "Physical Quantity"
+        },
+        "flag_is": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A list of items that a flag-value in this column stands for.",
+          "title": "Flag Is"
         },
         "comment": {
           "anyOf": [
@@ -1401,28 +1855,74 @@
             {
               "type": "null"
             }
-          ]
+          ],
+          "default": null,
+          "title": "Comment"
         }
       },
       "required": [
         "name"
-      ]
+      ],
+      "title": "R",
+      "type": "object"
     },
     "sR_column": {
-      "title": "sR",
-      "type": "object",
       "properties": {
         "error_of": {
-          "enum": [
-            "R"
-          ]
+          "title": "Error Of",
+          "type": "string"
         },
         "error_type": {
-          "enum": [
-            "uncertainty",
-            "resolution",
-            "null"
+          "anyOf": [
+            {
+              "enum": [
+                "uncertainty",
+                "resolution"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
           ],
+          "default": null,
+          "title": "Error Type"
+        },
+        "value_is": {
+          "anyOf": [
+            {
+              "enum": [
+                "sigma",
+                "FWHM"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Value Is"
+        },
+        "distribution": {
+          "anyOf": [
+            {
+              "enum": [
+                "gaussian",
+                "triangular",
+                "uniform",
+                "lorentzian"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Distribution"
+        },
+        "comment": {
           "anyOf": [
             {
               "type": "string"
@@ -1430,28 +1930,79 @@
             {
               "type": "null"
             }
+          ],
+          "default": null,
+          "title": "Comment"
+        },
+        "name": {
+          "enum": [
+            "sR"
           ]
         }
       },
       "required": [
         "error_of"
-      ]
+      ],
+      "title": "sR",
+      "type": "object"
     },
     "sQz_column": {
-      "title": "sQz",
-      "type": "object",
       "properties": {
         "error_of": {
-          "enum": [
-            "Qz"
-          ]
+          "title": "Error Of",
+          "type": "string"
         },
         "error_type": {
-          "enum": [
-            "uncertainty",
-            "resolution",
-            "null"
+          "anyOf": [
+            {
+              "enum": [
+                "uncertainty",
+                "resolution"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
           ],
+          "default": null,
+          "title": "Error Type"
+        },
+        "value_is": {
+          "anyOf": [
+            {
+              "enum": [
+                "sigma",
+                "FWHM"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Value Is"
+        },
+        "distribution": {
+          "anyOf": [
+            {
+              "enum": [
+                "gaussian",
+                "triangular",
+                "uniform",
+                "lorentzian"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Distribution"
+        },
+        "comment": {
           "anyOf": [
             {
               "type": "string"
@@ -1459,12 +2010,95 @@
             {
               "type": "null"
             }
+          ],
+          "default": null,
+          "title": "Comment"
+        },
+        "name": {
+          "enum": [
+            "sQz"
           ]
         }
       },
       "required": [
         "error_of"
-      ]
+      ],
+      "title": "sQz",
+      "type": "object"
     }
-  }
+  },
+  "properties": {
+    "data_source": {
+      "$ref": "#/$defs/DataSource"
+    },
+    "reduction": {
+      "$ref": "#/$defs/Reduction"
+    },
+    "columns": {
+      "anyOf": [
+        {
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/Column"
+          },
+          {
+            "$ref": "#/$defs/ErrorColumn"
+          }
+        ]
+      },
+      "prefixItems": [
+        {
+          "$ref": "#/$defs/Qz_column"
+        },
+        {
+          "$ref": "#/$defs/R_column"
+        },
+        {
+          "$ref": "#/$defs/sR_column"
+        },
+        {
+          "$ref": "#/$defs/sQz_column"
+        }
+      ]
+    },
+    "data_set": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    },
+    "comment": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "required": [
+    "data_source",
+    "reduction",
+    "columns"
+  ],
+  "title": "Orso",
+  "type": "object"
 }

--- a/orsopy/fileio/schema/refl_header.schema.yaml
+++ b/orsopy/fileio/schema/refl_header.schema.yaml
@@ -1,21 +1,20 @@
-$id: https://raw.githubusercontent.com/reflectivity/orsopy/v1.2.0/orsopy/fileio/schema/refl_header.schema.json
-$schema: http://json-schema.org/draft-07/schema#
-definitions:
+$defs:
   AlternatingField:
     properties:
       amplitude:
-        anyOf:
-        - $ref: '#/definitions/Value'
+        $ref: '#/$defs/Value'
       comment:
-        type:
-        - string
-        - 'null'
-      frequency:
         anyOf:
-        - $ref: '#/definitions/Value'
+        - type: string
+        - type: 'null'
+        default: null
+      frequency:
+        $ref: '#/$defs/Value'
       phase:
         anyOf:
-        - $ref: '#/definitions/Value'
+        - $ref: '#/$defs/Value'
+        - type: 'null'
+        default: null
     required:
     - amplitude
     - frequency
@@ -24,34 +23,38 @@ definitions:
   Column:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       flag_is:
+        anyOf:
+        - items:
+            type: string
+          type: array
+        - type: 'null'
+        default: null
         description: A list of items that a flag-value in this column stands for.
-        items:
-          type: string
-        type:
-        - array
-        - 'null'
       name:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
       physical_quantity:
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
         description: A description of the physical meaning for this column. For quantities
           defined by ORSO in header metadata the same name should be used.(For example
           'wavelength' or 'incident_angle' to indicate a column specifying those quantities
           on a point-by-point basis.)For canonical names of physical quantities see
           https://www.reflectometry.org/file_format/specification.
-        type:
-        - string
-        - 'null'
       unit:
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
         description: SI unit string
-        type:
-        - string
-        - 'null'
     required:
     - name
     title: Column
@@ -59,25 +62,30 @@ definitions:
   ComplexValue:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       error:
         anyOf:
-        - $ref: '#/definitions/ErrorValue'
+        - $ref: '#/$defs/ErrorValue'
+        - type: 'null'
+        default: null
       imag:
-        type:
-        - number
-        - 'null'
+        anyOf:
+        - type: number
+        - type: 'null'
+        default: null
       real:
-        type:
-        - number
-        - 'null'
+        anyOf:
+        - type: number
+        - type: 'null'
       unit:
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
         description: SI unit string
-        type:
-        - string
-        - 'null'
     required:
     - real
     title: ComplexValue
@@ -85,15 +93,16 @@ definitions:
   Composit:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       composition:
         additionalProperties:
           type: number
-        type:
-        - object
-        - 'null'
+        anyOf:
+        - type: object
+        - type: 'null'
     required:
     - composition
     title: Composit
@@ -101,21 +110,18 @@ definitions:
   DataSource:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       experiment:
-        anyOf:
-        - $ref: '#/definitions/Experiment'
+        $ref: '#/$defs/Experiment'
       measurement:
-        anyOf:
-        - $ref: '#/definitions/Measurement'
+        $ref: '#/$defs/Measurement'
       owner:
-        anyOf:
-        - $ref: '#/definitions/Person'
+        $ref: '#/$defs/Person'
       sample:
-        anyOf:
-        - $ref: '#/definitions/Sample'
+        $ref: '#/$defs/Sample'
     required:
     - owner
     - experiment
@@ -126,39 +132,40 @@ definitions:
   ErrorColumn:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       distribution:
-        enum:
-        - gaussian
-        - triangular
-        - uniform
-        - lorentzian
-        - null
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - enum:
+          - gaussian
+          - triangular
+          - uniform
+          - lorentzian
+          type: string
+        - type: 'null'
+        default: null
       error_of:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
       error_type:
-        enum:
-        - uncertainty
-        - resolution
-        - null
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - enum:
+          - uncertainty
+          - resolution
+          type: string
+        - type: 'null'
+        default: null
       value_is:
-        enum:
-        - sigma
-        - FWHM
-        - null
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - enum:
+          - sigma
+          - FWHM
+          type: string
+        - type: 'null'
+        default: null
     required:
     - error_of
     title: ErrorColumn
@@ -166,39 +173,40 @@ definitions:
   ErrorValue:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       distribution:
-        enum:
-        - gaussian
-        - triangular
-        - uniform
-        - lorentzian
-        - null
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - enum:
+          - gaussian
+          - triangular
+          - uniform
+          - lorentzian
+          type: string
+        - type: 'null'
+        default: null
       error_type:
-        enum:
-        - uncertainty
-        - resolution
-        - null
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - enum:
+          - uncertainty
+          - resolution
+          type: string
+        - type: 'null'
+        default: null
       error_value:
-        type:
-        - number
-        - 'null'
+        anyOf:
+        - type: number
+        - type: 'null'
       value_is:
-        enum:
-        - sigma
-        - FWHM
-        - null
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - enum:
+          - sigma
+          - FWHM
+          type: string
+        - type: 'null'
+        default: null
     required:
     - error_value
     title: ErrorValue
@@ -206,42 +214,46 @@ definitions:
   Experiment:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       doi:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       facility:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       instrument:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
       probe:
+        anyOf:
+        - type: string
+        - type: 'null'
         enum:
         - neutron
         - x-ray
         - null
-        type:
-        - string
-        - 'null'
       proposalID:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       start_date:
+        anyOf:
+        - type: string
+        - type: 'null'
         format: date-time
-        type:
-        - string
-        - 'null'
       title:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
     required:
     - title
     - instrument
@@ -252,20 +264,22 @@ definitions:
   File:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       file:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
       timestamp:
+        anyOf:
+        - format: date-time
+          type: string
+        - type: 'null'
+        default: null
         description: Last modified timestamp. If it's not specified, then an attempt
           will be made to check on the file itself
-        format: date-time
-        type:
-        - string
-        - 'null'
     required:
     - file
     title: File
@@ -273,31 +287,33 @@ definitions:
   InstrumentSettings:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       configuration:
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
         description: half / full polarized | liquid_surface | etc
-        type:
-        - string
-        - 'null'
       incident_angle:
         anyOf:
-        - $ref: '#/definitions/Value'
-        - $ref: '#/definitions/ValueRange'
+        - $ref: '#/$defs/Value'
+        - $ref: '#/$defs/ValueRange'
         - type: 'null'
       polarization:
         anyOf:
-        - $ref: '#/definitions/Polarization'
-        - $ref: '#/definitions/ValueVector'
+        - $ref: '#/$defs/Polarization'
+        - $ref: '#/$defs/ValueVector'
         - type: 'null'
         default: unpolarized
         description: Polarization described as unpolarized/ po/ mo / op / om / pp
           / pm / mp / mm / vector
       wavelength:
         anyOf:
-        - $ref: '#/definitions/Value'
-        - $ref: '#/definitions/ValueRange'
+        - $ref: '#/$defs/Value'
+        - $ref: '#/$defs/ValueRange'
         - type: 'null'
     required:
     - incident_angle
@@ -307,104 +323,117 @@ definitions:
   Layer:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
-      composition:
-        additionalProperties:
-          type: number
-        type:
-        - object
-        - 'null'
-      material:
         anyOf:
-        - $ref: '#/definitions/Material'
-        - $ref: '#/definitions/Composit'
         - type: string
         - type: 'null'
+        default: null
+      composition:
+        anyOf:
+        - additionalProperties:
+            type: number
+          type: object
+        - type: 'null'
+        default: null
+      material:
+        anyOf:
+        - $ref: '#/$defs/Material'
+        - $ref: '#/$defs/Composit'
+        - type: string
+        - type: 'null'
+        default: null
       roughness:
         anyOf:
         - type: number
-        - $ref: '#/definitions/Value'
+        - $ref: '#/$defs/Value'
         - type: 'null'
+        default: null
       thickness:
         anyOf:
         - type: number
-        - $ref: '#/definitions/Value'
+        - $ref: '#/$defs/Value'
         - type: 'null'
+        default: null
     title: Layer
     type: object
   Material:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       formula:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       magnetic_moment:
         anyOf:
         - type: number
-        - $ref: '#/definitions/Value'
+        - $ref: '#/$defs/Value'
         - type: 'null'
+        default: null
       mass_density:
         anyOf:
         - type: number
-        - $ref: '#/definitions/Value'
+        - $ref: '#/$defs/Value'
         - type: 'null'
+        default: null
       number_density:
         anyOf:
         - type: number
-        - $ref: '#/definitions/Value'
+        - $ref: '#/$defs/Value'
         - type: 'null'
+        default: null
       relative_density:
-        type:
-        - number
-        - 'null'
+        anyOf:
+        - type: number
+        - type: 'null'
+        default: null
       sld:
         anyOf:
         - type: number
-        - $ref: '#/definitions/ComplexValue'
-        - $ref: '#/definitions/Value'
+        - $ref: '#/$defs/ComplexValue'
+        - $ref: '#/$defs/Value'
         - type: 'null'
+        default: null
     title: Material
     type: object
   Measurement:
     properties:
       additional_files:
-        items:
-          anyOf:
-          - $ref: '#/definitions/File'
-          - type: string
-        type:
-        - array
-        - 'null'
-      comment:
-        type:
-        - string
-        - 'null'
-      data_files:
-        items:
-          anyOf:
-          - $ref: '#/definitions/File'
-          - type: string
-        type:
-        - array
-        - 'null'
-      instrument_settings:
         anyOf:
-        - $ref: '#/definitions/InstrumentSettings'
+        - items:
+            anyOf:
+            - $ref: '#/$defs/File'
+            - type: string
+          type: array
+        - type: 'null'
+        default: null
+      comment:
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
+      data_files:
+        anyOf:
+        - type: array
+        - type: 'null'
+        items:
+          anyOf:
+          - $ref: '#/$defs/File'
+          - type: string
+      instrument_settings:
+        $ref: '#/$defs/InstrumentSettings'
       scheme:
-        enum:
-        - angle- and energy-dispersive
-        - angle-dispersive
-        - energy-dispersive
-        - null
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - enum:
+          - angle- and energy-dispersive
+          - angle-dispersive
+          - energy-dispersive
+          type: string
+        - type: 'null'
+        default: null
     required:
     - instrument_settings
     - data_files
@@ -413,58 +442,60 @@ definitions:
   ModelParameters:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
-      length_unit:
-        default: nm
-        type:
-        - string
-        - 'null'
-      magnetic_moment_unit:
-        default: muB
-        type:
-        - string
-        - 'null'
-      mass_density_unit:
-        default: g/cm^3
-        type:
-        - string
-        - 'null'
-      number_density_unit:
-        default: 1/nm^3
-        type:
-        - string
-        - 'null'
-      roughness:
         anyOf:
-        - $ref: '#/definitions/Value'
+        - type: string
+        - type: 'null'
+        default: null
+      length_unit:
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: nm
+      magnetic_moment_unit:
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: muB
+      mass_density_unit:
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: g/cm^3
+      number_density_unit:
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: 1/nm^3
+      roughness:
+        $ref: '#/$defs/Value'
       sld_unit:
+        anyOf:
+        - type: string
+        - type: 'null'
         default: 1/angstrom^2
-        type:
-        - string
-        - 'null'
     title: ModelParameters
     type: object
   Person:
     properties:
       affiliation:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       contact:
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
         description: Contact (email) address
-        type:
-        - string
-        - 'null'
       name:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
     required:
     - name
     - affiliation
@@ -518,6 +549,17 @@ definitions:
         anyOf:
         - type: string
         - type: 'null'
+        default: null
+        title: Comment
+      flag_is:
+        anyOf:
+        - items:
+            type: string
+          type: array
+        - type: 'null'
+        default: null
+        description: A list of items that a flag-value in this column stands for.
+        title: Flag Is
       name:
         enum:
         - Qz
@@ -525,14 +567,20 @@ definitions:
         anyOf:
         - type: string
         - type: 'null'
-        physical_quantity: physical quantity the column describes
+        default: null
+        description: A description of the physical meaning for this column. For quantities
+          defined by ORSO in header metadata the same name should be used.(For example
+          'wavelength' or 'incident_angle' to indicate a column specifying those quantities
+          on a point-by-point basis.)For canonical names of physical quantities see
+          https://www.reflectometry.org/file_format/specification.
+        title: Physical Quantity
       unit:
         enum:
-        - 1/angstrom
+        - null
         - 1/nm
+        - 1/angstrom
         - '1'
         - 1/s
-        - null
     required:
     - name
     title: Qz
@@ -543,6 +591,17 @@ definitions:
         anyOf:
         - type: string
         - type: 'null'
+        default: null
+        title: Comment
+      flag_is:
+        anyOf:
+        - items:
+            type: string
+          type: array
+        - type: 'null'
+        default: null
+        description: A list of items that a flag-value in this column stands for.
+        title: Flag Is
       name:
         enum:
         - R
@@ -550,14 +609,20 @@ definitions:
         anyOf:
         - type: string
         - type: 'null'
-        physical_quantity: physical quantity the column describes
+        default: null
+        description: A description of the physical meaning for this column. For quantities
+          defined by ORSO in header metadata the same name should be used.(For example
+          'wavelength' or 'incident_angle' to indicate a column specifying those quantities
+          on a point-by-point basis.)For canonical names of physical quantities see
+          https://www.reflectometry.org/file_format/specification.
+        title: Physical Quantity
       unit:
         enum:
-        - 1/angstrom
+        - null
         - 1/nm
+        - 1/angstrom
         - '1'
         - 1/s
-        - null
     required:
     - name
     title: R
@@ -565,47 +630,55 @@ definitions:
   Reduction:
     properties:
       binary:
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
         description: Path to full information file
-        type:
-        - string
-        - 'null'
       call:
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
         description: The command line call used
-        type:
-        - string
-        - 'null'
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       computer:
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
         description: Computer used for reduction
-        type:
-        - string
-        - 'null'
       corrections:
-        items:
-          type: string
-        type:
-        - array
-        - 'null'
+        anyOf:
+        - items:
+            type: string
+          type: array
+        - type: 'null'
+        default: null
       creator:
         anyOf:
-        - $ref: '#/definitions/Person'
+        - $ref: '#/$defs/Person'
+        - type: 'null'
+        default: null
       script:
-        description: Path to reduction script or notebook
-        type:
-        - string
-        - 'null'
-      software:
         anyOf:
-        - $ref: '#/definitions/Software'
+        - type: string
+        - type: 'null'
+        default: null
+        description: Path to reduction script or notebook
+      software:
+        $ref: '#/$defs/Software'
       timestamp:
+        anyOf:
+        - format: date-time
+          type: string
+        - type: 'null'
+        default: null
         description: Timestamp string, formatted as ISO 8601 datetime
-        format: date-time
-        type:
-        - string
-        - 'null'
     required:
     - software
     title: Reduction
@@ -613,49 +686,59 @@ definitions:
   Sample:
     properties:
       category:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       composition:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       description:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       environment:
-        items:
-          type: string
-        type:
-        - array
-        - 'null'
+        anyOf:
+        - items:
+            type: string
+          type: array
+        - type: 'null'
+        default: null
       model:
         anyOf:
-        - $ref: '#/definitions/SampleModel'
+        - $ref: '#/$defs/SampleModel'
+        - type: 'null'
+        default: null
       name:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
       sample_parameters:
-        additionalProperties:
-          anyOf:
-          - $ref: '#/definitions/Value'
-          - $ref: '#/definitions/ValueRange'
-          - $ref: '#/definitions/ValueVector'
-          - $ref: '#/definitions/ComplexValue'
-          - $ref: '#/definitions/AlternatingField'
+        anyOf:
+        - additionalProperties:
+            anyOf:
+            - $ref: '#/$defs/Value'
+            - $ref: '#/$defs/ValueRange'
+            - $ref: '#/$defs/ValueVector'
+            - $ref: '#/$defs/ComplexValue'
+            - $ref: '#/$defs/AlternatingField'
+          type: object
+        - type: 'null'
+        default: null
         description: Using keys for parameters and Value* objects for values.
-        type:
-        - object
-        - 'null'
       size:
         anyOf:
-        - $ref: '#/definitions/ValueVector'
+        - $ref: '#/$defs/ValueVector'
+        - type: 'null'
+        default: null
     required:
     - name
     title: Sample
@@ -663,48 +746,57 @@ definitions:
   SampleModel:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       composits:
-        additionalProperties:
-          $ref: '#/definitions/Composit'
-        type:
-        - object
-        - 'null'
+        anyOf:
+        - additionalProperties:
+            $ref: '#/$defs/Composit'
+          type: object
+        - type: 'null'
+        default: null
       globals:
         anyOf:
-        - $ref: '#/definitions/ModelParameters'
+        - $ref: '#/$defs/ModelParameters'
+        - type: 'null'
+        default: null
       layers:
-        additionalProperties:
-          $ref: '#/definitions/Layer'
-        type:
-        - object
-        - 'null'
+        anyOf:
+        - additionalProperties:
+            $ref: '#/$defs/Layer'
+          type: object
+        - type: 'null'
+        default: null
       materials:
-        additionalProperties:
-          $ref: '#/definitions/Material'
-        type:
-        - object
-        - 'null'
+        anyOf:
+        - additionalProperties:
+            $ref: '#/$defs/Material'
+          type: object
+        - type: 'null'
+        default: null
       origin:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       reference:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       stack:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
       sub_stacks:
-        additionalProperties:
-          $ref: '#/definitions/SubStack'
-        type:
-        - object
-        - 'null'
+        anyOf:
+        - additionalProperties:
+            $ref: '#/$defs/SubStack'
+          type: object
+        - type: 'null'
+        default: null
     required:
     - stack
     title: SampleModel
@@ -712,21 +804,24 @@ definitions:
   Software:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       name:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
       platform:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       version:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
     required:
     - name
     title: Software
@@ -734,63 +829,74 @@ definitions:
   SubStack:
     properties:
       arguments:
-        items: {}
-        type:
-        - array
-        - 'null'
+        anyOf:
+        - items: {}
+          type: array
+        - type: 'null'
+        default: null
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       keywords:
-        type:
-        - object
-        - 'null'
+        anyOf:
+        - type: object
+        - type: 'null'
+        default: null
       repetitions:
+        anyOf:
+        - type: integer
+        - type: 'null'
         default: 1
-        type:
-        - integer
-        - 'null'
       represents:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       sequence:
-        items:
-          $ref: '#/definitions/Layer'
-        type:
-        - array
-        - 'null'
+        anyOf:
+        - items:
+            $ref: '#/$defs/Layer'
+          type: array
+        - type: 'null'
+        default: null
       stack:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
     title: SubStack
     type: object
   Value:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       error:
         anyOf:
-        - $ref: '#/definitions/ErrorValue'
+        - $ref: '#/$defs/ErrorValue'
+        - type: 'null'
+        default: null
       magnitude:
-        type:
-        - number
-        - 'null'
+        anyOf:
+        - type: number
+        - type: 'null'
       offset:
+        anyOf:
+        - type: number
+        - type: 'null'
+        default: null
         description: The offset applied to a value (e.g. motor) to retrieve the reported
           (corrected) magnitude
-        type:
-        - number
-        - 'null'
       unit:
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
         description: SI unit string
-        type:
-        - string
-        - 'null'
     required:
     - magnitude
     title: Value
@@ -798,36 +904,40 @@ definitions:
   ValueRange:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       individual_magnitudes:
+        anyOf:
+        - items:
+            type: number
+          type: array
+        - type: 'null'
+        default: null
         description: Can list each individual value that was present during the experiment,
           only for information.
-        items:
-          type: number
-        type:
-        - array
-        - 'null'
       max:
-        type:
-        - number
-        - 'null'
+        anyOf:
+        - type: number
+        - type: 'null'
       min:
-        type:
-        - number
-        - 'null'
+        anyOf:
+        - type: number
+        - type: 'null'
       offset:
+        anyOf:
+        - type: number
+        - type: 'null'
+        default: null
         description: The offset applied to a value (e.g. motor) to retrieve the reported
           (corrected) min/max
-        type:
-        - number
-        - 'null'
       unit:
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
         description: SI unit string
-        type:
-        - string
-        - 'null'
     required:
     - min
     - max
@@ -836,29 +946,33 @@ definitions:
   ValueVector:
     properties:
       comment:
-        type:
-        - string
-        - 'null'
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
       error:
         anyOf:
-        - $ref: '#/definitions/ErrorValue'
+        - $ref: '#/$defs/ErrorValue'
+        - type: 'null'
+        default: null
       unit:
+        anyOf:
+        - type: string
+        - type: 'null'
+        default: null
         description: SI unit string
-        type:
-        - string
-        - 'null'
       x:
-        type:
-        - number
-        - 'null'
+        anyOf:
+        - type: number
+        - type: 'null'
       y:
-        type:
-        - number
-        - 'null'
+        anyOf:
+        - type: number
+        - type: 'null'
       z:
-        type:
-        - number
-        - 'null'
+        anyOf:
+        - type: number
+        - type: 'null'
     required:
     - x
     - y
@@ -867,65 +981,129 @@ definitions:
     type: object
   sQz_column:
     properties:
-      error_of:
-        enum:
-        - Qz
-      error_type:
+      comment:
         anyOf:
         - type: string
         - type: 'null'
+        default: null
+        title: Comment
+      distribution:
+        anyOf:
+        - enum:
+          - gaussian
+          - triangular
+          - uniform
+          - lorentzian
+          type: string
+        - type: 'null'
+        default: null
+        title: Distribution
+      error_of:
+        title: Error Of
+        type: string
+      error_type:
+        anyOf:
+        - enum:
+          - uncertainty
+          - resolution
+          type: string
+        - type: 'null'
+        default: null
+        title: Error Type
+      name:
         enum:
-        - uncertainty
-        - resolution
-        - 'null'
+        - sQz
+      value_is:
+        anyOf:
+        - enum:
+          - sigma
+          - FWHM
+          type: string
+        - type: 'null'
+        default: null
+        title: Value Is
     required:
     - error_of
     title: sQz
     type: object
   sR_column:
     properties:
-      error_of:
-        enum:
-        - R
-      error_type:
+      comment:
         anyOf:
         - type: string
         - type: 'null'
+        default: null
+        title: Comment
+      distribution:
+        anyOf:
+        - enum:
+          - gaussian
+          - triangular
+          - uniform
+          - lorentzian
+          type: string
+        - type: 'null'
+        default: null
+        title: Distribution
+      error_of:
+        title: Error Of
+        type: string
+      error_type:
+        anyOf:
+        - enum:
+          - uncertainty
+          - resolution
+          type: string
+        - type: 'null'
+        default: null
+        title: Error Type
+      name:
         enum:
-        - uncertainty
-        - resolution
-        - 'null'
+        - sR
+      value_is:
+        anyOf:
+        - enum:
+          - sigma
+          - FWHM
+          type: string
+        - type: 'null'
+        default: null
+        title: Value Is
     required:
     - error_of
     title: sR
     type: object
+$id: https://raw.githubusercontent.com/reflectivity/orsopy/v1.1/orsopy/fileio/schema/refl_header.schema.json
+$schema: https://json-schema.org/draft/2020-12/schema
 properties:
   columns:
-    additionalItems:
-      $ref: '#/definitions/Column'
+    anyOf:
+    - type: array
+    - type: 'null'
     items:
-    - $ref: '#/definitions/Qz_column'
-    - $ref: '#/definitions/R_column'
-    - $ref: '#/definitions/sR_column'
-    - $ref: '#/definitions/sQz_column'
-    type:
-    - array
-    - 'null'
+      anyOf:
+      - $ref: '#/$defs/Column'
+      - $ref: '#/$defs/ErrorColumn'
+    prefixItems:
+    - $ref: '#/$defs/Qz_column'
+    - $ref: '#/$defs/R_column'
+    - $ref: '#/$defs/sR_column'
+    - $ref: '#/$defs/sQz_column'
   comment:
-    type:
-    - string
-    - 'null'
+    anyOf:
+    - type: string
+    - type: 'null'
+    default: null
   data_set:
     anyOf:
     - type: integer
     - type: string
     - type: 'null'
+    default: null
   data_source:
-    anyOf:
-    - $ref: '#/definitions/DataSource'
+    $ref: '#/$defs/DataSource'
   reduction:
-    anyOf:
-    - $ref: '#/definitions/Reduction'
+    $ref: '#/$defs/Reduction'
 required:
 - data_source
 - reduction

--- a/orsopy/fileio/tests/test_schema.py
+++ b/orsopy/fileio/tests/test_schema.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+import sys
 
 from pathlib import Path
 
@@ -41,14 +42,27 @@ class TestSchema(unittest.TestCase):
         _validate_header_data([test.to_dict()])
 
     def test_wrong_schema(self):
+        vi = sys.version_info
+
         with self.assertRaises(jsonschema.exceptions.ValidationError):
             _validate_header_data([{}])
         test = fileio.Orso.empty()
-        with self.assertRaises(jsonschema.exceptions.ValidationError):
-            test.columns[0].unit = "test_fail_unit"
-            _validate_header_data([test.to_dict()])
+
+        test.columns[0].unit = "test_fail_unit"
+        if vi.minor < 7:
+            with self.assertWarns(fileio.base.ORSOSchemaWarning):
+                _validate_header_data([test.to_dict()])
+        else:
+            with self.assertRaises(jsonschema.exceptions.ValidationError):
+                _validate_header_data([test.to_dict()])
+
         test.columns[0].unit = "1/nm"
         _validate_header_data([test.to_dict()])
-        with self.assertRaises(jsonschema.exceptions.ValidationError):
-            test.columns[1].name = "NotRightColumn"
-            _validate_header_data([test.to_dict()])
+        test.columns[1].name = "NotRightColumn"
+
+        if vi.minor < 7:
+            with self.assertWarns(fileio.base.ORSOSchemaWarning):
+                _validate_header_data([test.to_dict()])
+        else:
+            with self.assertRaises(jsonschema.exceptions.ValidationError):
+                _validate_header_data([test.to_dict()])

--- a/tools/header_schema.py
+++ b/tools/header_schema.py
@@ -2,72 +2,57 @@
 Generates the schema for an ORSO file,
 based on the Orso class (from orsopy.fileio.orso)
 """
-import functools
-import os
-
 from copy import deepcopy
-from typing import Any, Dict, List
+import os
+from typing import Dict, List
 
-from pydantic.dataclasses import dataclass as _dataclass
+from pydantic import TypeAdapter
+from pydantic.json_schema import GenerateJsonSchema, JsonSchemaValue
+from pydantic_core import core_schema
 
+import orsopy
+from orsopy.fileio import Orso, Column, ErrorColumn, ORSO_VERSION
 
-class PydanticConfig:
-    """ for schema generation, otherwise unused """
+# allow None as a value for any attribute
+ALLOW_NULL_ANYWHERE = True
 
-    arbitrary_types_allowed = True
-
-    @staticmethod
-    def schema_extra(schema: Dict[str, Any]) -> None:
-        for prop, value in schema.get("properties", {}).items():
-            value.pop("title", None)
-
+class OrsoGenerateJsonSchema(GenerateJsonSchema):
+    # def generate(self, schema, mode='validation'):
+    #     json_schema = super().generate(schema, mode=mode)
+    #     json_schema['title'] = 'ORSO Reflectivity Format Schema'
+    #     json_schema['$schema'] = self.schema_dialect
+    #     return json_schema
+    
+    def dataclass_schema(self, schema: core_schema.DataclassSchema) -> JsonSchemaValue:
+        json_schema = super().dataclass_schema(schema)
+        for prop, value in json_schema.get('properties', {}).items():
             # make the schema accept None as a value for any of the
             # Header class attributes.
-            if "enum" in value:
-                value["enum"].append(None)
+            value.pop('title', None)
+            if ALLOW_NULL_ANYWHERE:
+                if 'enum' in value and not None in value['enum']:
+                    value['enum'].append(None)
+                if 'type' in value:
+                    value['anyOf'] = [{'type': value.pop('type')}]
+                if "anyOf" in value and not {"type": "null"} in value['anyOf']:
+                    value['anyOf'].append({'type': 'null'})
 
-            if "type" in value:
-                value["type"] = [value.pop("type"), "null"]
-            elif "anyOf" in value:
-                value["anyOf"].append({"type": "null"})
-            # only one $ref e.g. from other model
-            elif "$ref" in value:
-                value["anyOf"] = [{"$ref": value.pop("$ref")}]
+        return json_schema
 
-
-pydantic_dataclass = functools.partial(_dataclass, config=PydanticConfig)
 
 ADD_COLUMN_ORDER = True
-COLUMN_ORDER = ["Qz", "R", "sR", "sQz"]
+COLUMN_ORDER = ["Qz", "R"]
+ERROR_COLUMN_ORDER = ["sR", "sQz"]
 SCHEMA_URL = "https://raw.githubusercontent.com/reflectivity/orsopy/v{}/orsopy/fileio/schema/refl_header.schema.json"
+DEFINITIONS_KEY = "$defs"
+
+column_schema = TypeAdapter(Column).json_schema()
+# TODO: set proper enum for unit, this will fail for additional columns e.g. wavelength
+column_schema["properties"]["unit"] = {"enum" : [None, "1/nm", "1/angstrom", "1", "1/s"]}
+error_column_schema = TypeAdapter(ErrorColumn).json_schema()
 
 
-column_schema = {
-    "title": "<cname>",
-    "type": "object",
-    "properties": {
-        "name": {"enum": ["<cname>"]},
-        "unit": {"enum": ["1/angstrom", "1/nm", "1", "1/s", None]},
-        "physical_quantity": {
-            "physical_quantity": "physical quantity the column describes",
-            "anyOf": [{"type": "string"}, {"type": "null"}],
-        },
-        "comment": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-    },
-    "required": ["name"],
-}
-error_schema = {
-    "title": "<cname>",
-    "type": "object",
-    "properties": {
-        "error_of": {"enum": ["<cname>"]},
-        "error_type": {"enum": ["uncertainty", "resolution", "null"], "anyOf": [{"type": "string"}, {"type": "null"}]},
-    },
-    "required": ["error_of"],
-}
-
-
-def add_column_ordering(schema: Dict, column_order: List[str] = COLUMN_ORDER):
+def add_column_ordering(schema: Dict, column_order: List[str] = COLUMN_ORDER, error_column_order: List[str] = ERROR_COLUMN_ORDER):
     """
     Add constraints for the order of column names
     (note: modifies schema dict in-place)
@@ -81,34 +66,36 @@ def add_column_ordering(schema: Dict, column_order: List[str] = COLUMN_ORDER):
     """
     columns = {}
     for cname in column_order:
-        if cname.startswith("s"):
-            cdef = deepcopy(error_schema)
-            cdef["title"] = cname
-            cdef["properties"]["error_of"]["enum"][0] = cname[1:]
-            columns[f"{cname}_column"] = cdef
-        else:
-            cdef = deepcopy(column_schema)
-            cdef["title"] = cname
-            cdef["properties"]["name"]["enum"][0] = cname
-            columns[f"{cname}_column"] = cdef
+        cdef = deepcopy(column_schema)
+        cdef["title"] = cname
+        cdef["properties"]["name"] = {"enum": [cname]}
+        columns[f"{cname}_column"] = cdef
 
-    schema["definitions"].update(columns)
-    schema["properties"]["columns"]["items"] = [{"$ref": f"#/definitions/{cname}_column"} for cname in column_order]
-    schema["properties"]["columns"]["additionalItems"] = {"$ref": "#/definitions/Column"}
+    for cname in error_column_order:
+        cdef = deepcopy(error_column_schema)
+        cdef["title"] = cname
+        cdef["properties"]["name"] = {"enum": [cname]}
+        columns[f"{cname}_column"] = cdef
 
+    schema[DEFINITIONS_KEY].update(columns)
+    schema["properties"]["columns"]["prefixItems"] = [
+        {"$ref": f"#/{DEFINITIONS_KEY}/{cname}_column"} for cname in (column_order + error_column_order)
+    ]
+    schema["properties"]["columns"]["items"] = {
+        "anyOf": [
+             {"$ref": f"#/{DEFINITIONS_KEY}/Column"},
+             {"$ref": f"#/{DEFINITIONS_KEY}/ErrorColumn"},
+        ]
+    }
+   
 
 def main():
-    import orsopy
-
-    orsopy.dataclass = pydantic_dataclass
-    from orsopy import __version__
-    from orsopy.fileio import Header, Orso
-
     schema = {
-        "$schema": "http://json-schema.org/draft-07/schema#",
-        "$id": SCHEMA_URL.format(__version__),
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": SCHEMA_URL.format(ORSO_VERSION),
     }
-    schema.update(Orso.__pydantic_model__.schema())
+    orso_schema = TypeAdapter(Orso).json_schema(schema_generator=OrsoGenerateJsonSchema)
+    schema.update(orso_schema)
     if ADD_COLUMN_ORDER:
         add_column_ordering(schema)
 
@@ -119,14 +106,18 @@ def main():
     print(f"writing JSON schema: {json_output_file}")
     import json
 
-    open(json_output_file, "wt").write(json.dumps(schema, indent=2))
+    open(json_output_file, "wt").write(
+        json.dumps(schema, indent=2)
+    )
 
     # generate yaml schema, and write out:
     yaml_output_file = os.path.join(schema_path, "refl_header.schema.yaml")
     print(f"writing YAML schema: {yaml_output_file}")
     import yaml
 
-    open(yaml_output_file, "w").write(yaml.dump(schema))
+    open(yaml_output_file, "w").write(
+        yaml.dump(schema)
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Using pydantic v2.x, we can use a TypeAdapter to convert stdlib dataclasses to a pydantic model, which we can then use to generate a schema.  

This removes the need to use pydantic dataclasses, and therefore we don't need the indirect import of the dataclass decorator from a central location (which was previously monkey-patched when generating the schema)

I ran across an issue with the `Column.unit` attribute: in the old schema generator, a constraint was manually added to that attribute at schema-generation time which restricted the value to one of `["1/angstrom", "1/nm", "1", "1/s", None]`, which is ok for the `Qz` and `R` columns but which won't work for additional columns like `wavelength` (see #125)

For the moment I replicated the old behavior, with a note that it needs to be changed (existing tests all pass right now)