### PR TITLE
Validity check api

### DIFF
--- a/examples/prist5_10K_m_025.Rqz.ort
+++ b/examples/prist5_10K_m_025.Rqz.ort
@@ -2,8 +2,8 @@
 # data_source:
 #   owner:
 #     name: Artur Glavic
-#     affiliation: null
-#     contact: b''
+#     affiliation: ''
+#     contact: ''
 #   experiment:
 #     title: Structural evolution of the CO2/Water interface
 #     instrument: Amor
@@ -39,7 +39,7 @@
 # data_set: 0
 # columns:
 # - {name: Qz, unit: 1/angstrom, physical_quantity: normal momentum transfer}
-# - {name: R, unit: '', physical_quantity: specular reflectivity}
+# - {name: R, unit: '1', physical_quantity: specular reflectivity}
 # - {error_of: R, error_type: uncertainty, value_is: sigma}
 # - {error_of: Qz, error_type: resolution, value_is: sigma}
 # # Qz (1/angstrom)    R ()                   sR                     sQz                   

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -71,6 +71,37 @@ class ORSOValidationResult:
     def __bool__(self):
         return self.valid
 
+    @staticmethod
+    def _pprint_list(items, title):
+        output = ""
+        if len(items) > 0:
+            output += f"  {title}\n    "
+            for i in items:
+                output += f"{i}, "
+            output = output[:-2] + "\n"
+        return output
+
+    def get_report(self):
+        """
+        Returns a summary report of the validation result helping to analyze issues with the data..
+        """
+        if self.valid:
+            output = f"Dictionary was a valid {self.header_class.__name__} dataset\n"
+            output += self._pprint_list(self.missing_optionals, "Optional extra parameters that could be provided")
+            output += self._pprint_list(self.user_parameters, "User parameters not part of specification")
+            return output
+        else:
+            output = f"Dictionary was invalid for {self.header_class.__name__}!\n  Reasons for classification:\n"
+            output += self._pprint_list(self.user_parameters, "User parameters not part of specification")
+            output += self._pprint_list(self.missing_attributes, "Required parameters not provided")
+            output += self._pprint_list(self.invalid_attributes, "Parameters with invalid type or attributes")
+            for ia in self.invalid_attributes:
+                if ia in self.attribute_validations:
+                    output += f"    ORSO parameter {ia} extra information:\n      "
+                    output += self.attribute_validations[ia].get_report().replace("\n", "\n      ")
+                    output += "\n"
+            return output
+
 
 class Header:
     """

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -213,11 +213,12 @@ class Header:
                             if type(subt) is type and issubclass(subt, Header):
                                 result = subt.check_valid(value, user_is_valid=user_is_valid)
                                 if result:
+                                    failed_results = []
                                     break
                                 else:
                                     failed_results.append(result)
                         if len(failed_results) > 0:
-                            # select best fitting of results, in case there are multiple Header in a Union
+                            # select best fitting of failed results, in case there are multiple Header in a Union
                             best_match = failed_results[0]
                             for failed_result in failed_results:
                                 if (len(failed_result.missing_attributes) + len(failed_result.invalid_attributes)) < (

--- a/orsopy/fileio/base.py
+++ b/orsopy/fileio/base.py
@@ -247,7 +247,7 @@ class Header:
                             invalid_attributes.append(key)
                     if updt is None:
                         invalid_attributes.append(key)
-                    elif type_value is not dict and type(updt) is not type_value:
+                    elif type_value is not dict and not isinstance(updt, type_value):
                         invalid_attributes.append(key)
                 construct_fields.pop(field_keys.index(key))
                 field_keys.pop(field_keys.index(key))

--- a/orsopy/fileio/orso.py
+++ b/orsopy/fileio/orso.py
@@ -251,14 +251,14 @@ def save_orso(
             np.savetxt(f, dsi.data, header=hi, fmt="%-22.16e")
 
 
-def load_orso(fname: Union[TextIO, str]) -> List[OrsoDataset]:
+def load_orso(fname: Union[TextIO, str], validate=False) -> List[OrsoDataset]:
     """
     :param fname: The Orso file to load.
 
     :return: :py:class:`OrsoDataset` objects for each dataset contained
         within the ORT file.
     """
-    dct_list, datas, version = _read_header_data(fname)
+    dct_list, datas, version = _read_header_data(fname, validate=validate)
     ods = []
 
     for dct, data in zip(dct_list, datas):

--- a/orsopy/fileio/tests/test_orso.py
+++ b/orsopy/fileio/tests/test_orso.py
@@ -34,19 +34,27 @@ class TestOrso(unittest.TestCase):
         Creation of Orso object.
         """
         e = Experiment("Experiment 1", "ESTIA", datetime(2021, 7, 7, 16, 31, 10), "neutron")
+        assert Experiment.check_valid(e.to_dict())
         s = Sample("The sample")
-        inst = InstrumentSettings(Value(4.0, "deg"), ValueRange(2.0, 12.0, "angstrom"))
+        assert Sample.check_valid(s.to_dict())
+        inst = InstrumentSettings(Value(4.0, "deg"), ValueRange(2.0, 12.0, "angstrom"), Polarization.unpolarized)
+        assert InstrumentSettings.check_valid(inst.to_dict())
         df = [File("README.rst", None)]
         m = Measurement(inst, df, scheme="angle-dispersive")
+        assert Measurement.check_valid(m.to_dict())
         p = Person("A Person", "Some Uni")
+        assert Person.check_valid(p.to_dict())
         ds = DataSource(p, e, s, m)
+        assert DataSource.check_valid(ds.to_dict())
 
         soft = Software("orsopy", "0.0.1", "macOS-10.15")
         p2 = Person("Andrew McCluskey", "European Spallation Source")
         redn = Reduction(soft, datetime(2021, 7, 14, 10, 10, 10), p2, ["footprint", "background"])
+        assert Reduction.check_valid(redn.to_dict())
 
         cols = [Column("Qz", unit="1/angstrom"), Column("R")]
         value = Orso(ds, redn, cols, 0)
+        assert Orso.check_valid(value.to_dict())
 
         ds = value.data_source
         dsm = ds.measurement
@@ -87,6 +95,11 @@ class TestOrso(unittest.TestCase):
 
         cols = [Column("Qz", unit="1/angstrom"), Column("R")]
         value = Orso(ds, redn, cols, 1)
+        assert Orso.check_valid(value.to_dict())
+        # add a user parameter, which is invalid by default
+        value.data_source.test_user = "abc"
+        self.assertFalse(Orso.check_valid(value.to_dict()).valid)
+        assert Orso.check_valid(value.to_dict(), user_is_valid=True)
 
         dsm = value.data_source.measurement
         assert value.data_source.owner.name == "A Person"
@@ -132,14 +145,22 @@ class TestOrso(unittest.TestCase):
 
         info3 = fileio.Orso(
             data_source=fileio.DataSource(
-                sample=fileio.Sample(name="My Sample", category="solid", description="Something descriptive",),
+                sample=fileio.Sample(
+                    name="My Sample",
+                    category="solid",
+                    description="Something descriptive",
+                ),
                 experiment=fileio.Experiment(
-                    title="Main experiment", instrument="Reflectometer", start_date=datetime.now(), probe="x-ray",
+                    title="Main experiment",
+                    instrument="Reflectometer",
+                    start_date=datetime.now(),
+                    probe="x-ray",
                 ),
                 owner=fileio.Person("someone", "important"),
                 measurement=fileio.Measurement(
                     instrument_settings=fileio.InstrumentSettings(
-                        incident_angle=fileio.Value(13.4, "deg"), wavelength=fileio.Value(5.34, "A"),
+                        incident_angle=fileio.Value(13.4, "deg"),
+                        wavelength=fileio.Value(5.34, "A"),
                     ),
                     data_files=["abc", "def", "ghi"],
                     scheme="angle-dispersive",


### PR DESCRIPTION
As pointed out  by @andyfaff in #143 it can be hard to validate the Orso header data and find out which attributes are missing/wrong. This adds a `check_valid` method to each Header derived class that can be used to check a dictionary for correctness and get detailed information on the issues if it is invalid.

The returned class includes a list of any missing or invalid attributes as well as sub-attribute details. with `ORSOValidationResult.get_report()` the results are summarized so users of the API can quickly fix what is missing.

Examples:
```python
from orsopy.fileio import *
print(
    Person.check_valid({'name': 'Test User', 'affiliacion': 'Test'}).get_report()
)
> Dictionary was invalid for Person!
>    Reasons for classification:
>    User parameters not part of specification
>      affiliacion
>    Required parameters not provided
>      affiliation

print(
    InstrumentSettings.check_valid({
        'incident_angle': {'magnitude': 4.0, 'unit': 'deg'}, 
        'wavelength': {'min': 2.0, 'max': 12.0, 'unit': 12}, 
        'polarization': 'unpolarized'}).get_report()
)
>  Dictionary was invalid for InstrumentSettings!
>    Reasons for classification:
>    Parameters with invalid type or attributes
>      wavelength
>      ORSO parameter wavelength extra information:
>        Dictionary was invalid for ValueRange!
>          Reasons for classification:
>          Parameters with invalid type or attributes
```

This should work arbitrarily deep, as illustrated by putting the previous result into a DataSource:
```python
Dictionary was invalid for DataSource!
  Reasons for classification:
  Parameters with invalid type or attributes
    measurement
    ORSO parameter measurement extra information:
      Dictionary was invalid for Measurement!
        Reasons for classification:
        Parameters with invalid type or attributes
          instrument_settings
          ORSO parameter instrument_settings extra information:
            Dictionary was invalid for InstrumentSettings!
              Reasons for classification:
              Parameters with invalid type or attributes
                wavelength
                ORSO parameter wavelength extra information:
                  Dictionary was invalid for ValueRange!
                    Reasons for classification:
                    Parameters with invalid type or attributes
                      unit
```