### PR TITLE
Fix sample model slddb resolver not returning magnetic moment

### DIFF
--- a/orsopy/fileio/model_building_blocks.py
+++ b/orsopy/fileio/model_building_blocks.py
@@ -262,9 +262,7 @@ class Layer(Header):
                             break
                     if res:
                         # could resolve the string to an actual material
-                        self.material = Material(
-                            formula=res["formula"], number_density=res["number_density"], comment=res["comment"]
-                        )
+                        self.material = Material.from_dict(res)
                     else:
                         # will lead to errors later but keep string as formula
                         self.material = Material(formula=self.material)

--- a/orsopy/utils/resolver_slddb.py
+++ b/orsopy/utils/resolver_slddb.py
@@ -26,6 +26,8 @@ class ResolverSLDDB(MaterialResolver):
                         "number_density": 1e3 * m.fu_dens,
                         "comment": self.comment,
                     }
+                    if m.mu > 0:
+                        out["mu"] = m.mu
                     return out
             if prefix.lower() in ("protein", "dna", "rna"):
                 m = api.bio_blender(name.split("=")[1], prefix)
@@ -49,6 +51,8 @@ class ResolverSLDDB(MaterialResolver):
                     "number_density": 1e3 * m.fu_dens,
                     "comment": self.comment,
                 }
+                if m.mu > 0:
+                    out["mu"] = m.mu
                 return out
         return None
 


### PR DESCRIPTION
Although the slddb resolver receives magnetic moment data from SLDdb it was not returned to the sample model resolver, this fixes that issue.

Also adds the possibility for the resolver to return any keys that are attributes of the Material class.