### PR TITLE
add numpy requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ python_requires = >=3.8
 packages = find:
 install_requires =
     pyyaml>=5.4.1
-    numpy>=1.26.0
+    numpy>=1.19.0
 include_package_data = True
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ python_requires = >=3.8
 packages = find:
 install_requires =
     pyyaml>=5.4.1
+    numpy>=1.26.0
 include_package_data = True
 
 [options.package_data]


### PR DESCRIPTION
The libraries use numpy in multiple places as a top-level import, so it should really be a dependency.  

Doing `pip install orsopy` then in python doing `import orsopy.fileio` currently raises an error because of this.